### PR TITLE
Style bottom navigation bar

### DIFF
--- a/app/src/main/res/drawable/bottom_nav_background.xml
+++ b/app/src/main/res/drawable/bottom_nav_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/bottomNavBackground" />
+    <corners android:topLeftRadius="16dp" android:topRightRadius="16dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,8 +20,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:background="@color/bottomNavBackground"
-        app:itemIconTint="@color/bottom_nav_item_color_selector" 
+        android:layout_margin="16dp"
+        android:background="@drawable/bottom_nav_background"
+        android:elevation="8dp"
+        app:itemIconSize="24dp"
+        app:itemIconTint="@color/bottom_nav_item_color_selector"
+        app:itemRippleColor="@color/bottomNavRipple"
         app:itemTextColor="@color/bottom_nav_item_color_selector"
         app:menu="@menu/bottom_nav_menu" />
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -7,4 +7,5 @@
     <color name="bottomNavBackground">#000000</color>
     <color name="bottomNavItemActive">#1F7A8C</color>
     <color name="bottomNavItemInactive">#FFFFFF</color>
+    <color name="bottomNavRipple">#33FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -32,6 +32,7 @@
     <color name="bottomNavBackground">@color/palette_white</color>
     <color name="bottomNavItemActive">@color/palette_teal</color>
     <color name="bottomNavItemInactive">@color/palette_dark_blue</color>
+    <color name="bottomNavRipple">#331F7A8C</color>
     <color name="primary_blue">@color/palette_dark_blue</color>
     <color name="colorSuccess">#4CAF50</color>
     <color name="colorWarning">#F44336</color>


### PR DESCRIPTION
## Summary
- Improve bottom nav appearance with rounded background, margin, elevation, and ripple effect
- Add color resources for ripple in both light and dark themes

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed31417483338893746dc51aa8f6