### PR TITLE
Modernize home screen styling

### DIFF
--- a/app/src/main/java/com/example/carrentingtest/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/carrentingtest/fragments/HomeFragment.java
@@ -194,21 +194,30 @@ public class HomeFragment extends Fragment {
     private void updateButtonStyles() {
         int selectedColor = ContextCompat.getColor(requireContext(), R.color.colorPrimary);
         ColorStateList selectedTextColor = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.colorOnPrimary));
-        int defaultColor = ContextCompat.getColor(requireContext(), R.color.colorSurface); // Or another default background
+        int defaultColor = ContextCompat.getColor(requireContext(), R.color.homeFilterDefaultBackground);
         ColorStateList defaultTextColor = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.colorPrimary));
-        ColorStateList defaultStrokeColor = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.colorPrimary));
+        ColorStateList defaultStrokeColor = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.homeFilterStroke));
+        ColorStateList rippleColor = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.homeFilterRipple));
+        int strokeWidth = getResources().getDimensionPixelSize(R.dimen.home_filter_chip_stroke_width);
 
         for (int i = 0; i < filterContainer.getChildCount(); i++) {
             View child = filterContainer.getChildAt(i);
             if (child instanceof MaterialButton) {
                 MaterialButton button = (MaterialButton) child;
                 String buttonType = button.getText().toString();
+                boolean isSelected = buttonType.equalsIgnoreCase(currentFilterType);
 
-                if (buttonType.equalsIgnoreCase(currentFilterType)) {
-                    // Selected style
+                button.setRippleColor(rippleColor);
+
+                if (isSelected) {
                     button.setBackgroundTintList(ColorStateList.valueOf(selectedColor));
                     button.setTextColor(selectedTextColor);
-                    button.setStrokeWidth(0); // Remove stroke for selected filled button
+                    button.setStrokeWidth(0);
+                } else {
+                    button.setBackgroundTintList(ColorStateList.valueOf(defaultColor));
+                    button.setTextColor(defaultTextColor);
+                    button.setStrokeColor(defaultStrokeColor);
+                    button.setStrokeWidth(strokeWidth);
                 }
             }
         }

--- a/app/src/main/res/drawable/bg_badge_soft.xml
+++ b/app/src/main/res/drawable/bg_badge_soft.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+    <corners android:radius="50dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_chip_soft.xml
+++ b/app/src/main/res/drawable/bg_chip_soft.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/homeChipBackground" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/homeChipStroke" />
+    <corners android:radius="50dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_home_hero.xml
+++ b/app/src/main/res/drawable/bg_home_hero.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:startColor="@color/homeHeroStart"
+        android:endColor="@color/homeHeroEnd"
+        android:angle="120" />
+    <corners android:radius="24dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_search_bar.xml
+++ b/app/src/main/res/drawable/bg_search_bar.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/homeSearchBackground" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/homeSearchStroke" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -4,73 +4,100 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="@color/white">
+    android:background="@color/homeBackground"
+    android:paddingHorizontal="@dimen/home_horizontal_padding"
+    android:paddingTop="@dimen/home_section_spacing"
+    android:paddingBottom="16dp">
 
     <!-- Hero Section -->
-    <LinearLayout
-        android:layout_margin="5dp"
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_marginBottom="10dp">
+        android:layout_marginBottom="24dp"
+        app:cardBackgroundColor="@android:color/transparent"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="0dp"
+        app:cardUseCompatPadding="false"
+        app:strokeWidth="0dp">
 
-        <TextView
-            android:id="@+id/heroTitle"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/find_perfect_car"
-            android:textSize="20sp"
-            android:textStyle="bold"
-            android:textColor="@color/textColorPrimary"
-            android:fontFamily="sans-serif-medium"/>
+            android:background="@drawable/bg_home_hero"
+            android:orientation="vertical"
+            android:padding="24dp">
 
-        <TextView
-            android:id="@+id/heroSubtitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/choose_from_selection"
-            android:textSize="14sp"
-            android:textColor="@color/textColorSecondary"
-            android:layout_marginTop="4dp"/>
-    </LinearLayout>
+            <TextView
+                android:id="@+id/heroTagline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/home_tagline"
+                android:textAllCaps="true"
+                android:textColor="@color/colorOnPrimary"
+                android:textSize="12sp"
+                android:letterSpacing="0.08"
+                android:fontFamily="sans-serif-medium" />
+
+            <TextView
+                android:id="@+id/heroTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="sans-serif-medium"
+                android:text="@string/find_perfect_car"
+                android:textColor="@color/colorOnPrimary"
+                android:textSize="24sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/heroSubtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/home_subtitle"
+                android:textColor="@color/colorOnPrimary"
+                android:textSize="14sp"
+                android:alpha="0.85" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 
     <!-- Search -->
-    <com.google.android.material.card.MaterialCardView
-        android:layout_margin="5dp"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="10dp"
-        app:cardBackgroundColor="@color/colorSurface"
-        app:cardCornerRadius="12dp"
-        app:cardElevation="2dp">
+        android:layout_marginBottom="20dp"
+        android:background="@drawable/bg_search_bar"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="6dp">
 
         <androidx.appcompat.widget.SearchView
             android:id="@+id/searchView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:queryHint="Search by model..."
             android:background="@android:color/transparent"
-            app:iconifiedByDefault="false"
-            android:padding="4dp"/>
-    </com.google.android.material.card.MaterialCardView>
+            android:iconifiedByDefault="false"
+            android:queryHint="@string/search_cars_hint"
+            android:paddingHorizontal="4dp"
+            app:queryBackground="@android:color/transparent" />
+    </LinearLayout>
 
     <!-- Category Filter -->
     <TextView
-        android:layout_margin="5dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/categories"
-        android:textSize="16sp"
-        android:textStyle="bold"
+        android:layout_marginBottom="12dp"
+        android:text="@string/home_categories_title"
         android:textColor="@color/textColorPrimary"
-        android:layout_marginBottom="8dp"/>
+        android:textSize="16sp"
+        android:textStyle="bold" />
 
     <HorizontalScrollView
-        android:layout_margin="5dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:scrollbars="none"
-        android:layout_marginBottom="16dp">
+        android:layout_marginBottom="20dp"
+        android:overScrollMode="never"
+        android:scrollbars="none">
 
         <LinearLayout
             android:id="@+id/filterContainer"
@@ -80,32 +107,48 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnAll"
-                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
                 android:text="@string/all"
-                app:backgroundTint="@color/colorPrimary"
-                android:textColor="@color/colorOnPrimary"/>
+                android:textAllCaps="false"
+                android:textColor="@color/colorPrimary"
+                android:textSize="14sp"
+                app:backgroundTint="@color/homeFilterDefaultBackground"
+                app:cornerRadius="50dp"
+                app:strokeColor="@color/homeFilterStroke"
+                app:strokeWidth="1dp" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnSUV"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
                 android:text="@string/suv"
-                android:layout_marginStart="8dp"
-                app:strokeColor="@color/colorPrimary"
-                android:textColor="@color/colorPrimary"/>
+                android:textAllCaps="false"
+                android:textColor="@color/colorPrimary"
+                android:textSize="14sp"
+                app:backgroundTint="@color/homeFilterDefaultBackground"
+                app:cornerRadius="50dp"
+                app:strokeColor="@color/homeFilterStroke"
+                app:strokeWidth="1dp" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnCompact"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
                 android:text="@string/compact"
-                android:layout_marginStart="8dp"
-                app:strokeColor="@color/colorPrimary"
-                android:textColor="@color/colorPrimary"/>
+                android:textAllCaps="false"
+                android:textColor="@color/colorPrimary"
+                android:textSize="14sp"
+                app:backgroundTint="@color/homeFilterDefaultBackground"
+                app:cornerRadius="50dp"
+                app:strokeColor="@color/homeFilterStroke"
+                app:strokeWidth="1dp" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnLuxury"
@@ -113,22 +156,25 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/luxury"
-                android:layout_marginStart="8dp"
-                app:strokeColor="@color/colorPrimary"
-                android:textColor="@color/colorPrimary"/>
+                android:textAllCaps="false"
+                android:textColor="@color/colorPrimary"
+                android:textSize="14sp"
+                app:backgroundTint="@color/homeFilterDefaultBackground"
+                app:cornerRadius="50dp"
+                app:strokeColor="@color/homeFilterStroke"
+                app:strokeWidth="1dp" />
         </LinearLayout>
     </HorizontalScrollView>
 
     <!-- ListView -->
     <ListView
-        android:padding="8dp"
-        android:layout_marginBottom="10dp"
         android:id="@+id/carsListView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
+        android:clipToPadding="false"
         android:divider="@android:color/transparent"
         android:dividerHeight="16dp"
-        android:clipToPadding="false"/>
+        android:paddingBottom="8dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_car.xml
+++ b/app/src/main/res/layout/item_car.xml
@@ -1,131 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
+<com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    card_view:cardCornerRadius="16dp"
-    card_view:cardElevation="8dp"
-    card_view:cardBackgroundColor="#FFFFFF">
+    android:foreground="?attr/selectableItemBackground"
+    app:cardBackgroundColor="@color/colorSurface"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="2dp"
+    app:cardUseCompatPadding="false"
+    app:strokeColor="@color/homeCardStroke"
+    app:strokeWidth="1dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:background="#FFFFFF">
+        android:orientation="vertical">
 
-        <ImageView
-            android:id="@+id/carImage"
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="150dp"
-            android:scaleType="centerCrop"
-            android:src="@drawable/ic_app_logo"
-            android:contentDescription="Car Image"
-            android:background="#E1E5F2" />
+            android:layout_height="180dp"
+            android:background="@color/homeChipBackground">
+
+            <ImageView
+                android:id="@+id/carImage"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/car_image_content_description"
+                android:scaleType="centerCrop"
+                android:src="@drawable/ic_app_logo" />
+
+            <TextView
+                android:id="@+id/carAvailability"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|top"
+                android:layout_margin="12dp"
+                android:background="@drawable/bg_badge_soft"
+                android:backgroundTint="@color/primary_blue"
+                android:gravity="center"
+                android:paddingHorizontal="12dp"
+                android:paddingVertical="6dp"
+                android:text="@string/car_available"
+                android:textAllCaps="false"
+                android:textColor="@color/colorOnPrimary"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                android:visibility="visible" />
+        </FrameLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:padding="20dp">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/carModel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <!-- Car Model -->
-                <TextView
-                    android:id="@+id/carModel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/car_model"
-                    android:textColor="#022B3A"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
-                    android:maxLines="1"
-                    android:ellipsize="end" />
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:maxLines="1"
+                android:text="@string/car_model"
+                android:textColor="@color/textColorPrimary"
+                android:textSize="18sp"
+                android:textStyle="bold" />
 
-                <Space
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1" />
-
-                <!-- Car Type Row -->
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="6dp"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
-
-                    <ImageView
-                        android:layout_width="18dp"
-                        android:layout_height="18dp"
-                        android:src="@drawable/ic_type"
-                        android:layout_marginEnd="6dp"
-                        card_view:tint="#1F7A8C" />
-
-                    <TextView
-                        android:id="@+id/carType"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/suv"
-                        android:textColor="#1F7A8C"
-                        android:textSize="14sp" />
-                </LinearLayout>
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <TextView
+                android:id="@+id/carType"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:orientation="horizontal">
-                <!-- Price -->
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
+                android:layout_marginTop="10dp"
+                android:background="@drawable/bg_chip_soft"
+                android:paddingHorizontal="12dp"
+                android:paddingVertical="6dp"
+                android:text="@string/suv"
+                android:textAllCaps="false"
+                android:textColor="@color/colorPrimary"
+                android:textSize="13sp" />
 
-                    <ImageView
-                        android:layout_width="18dp"
-                        android:layout_height="18dp"
-                        android:src="@drawable/ic_price"
-                        android:layout_marginEnd="6dp"
-                        card_view:tint="#1F7A8C" />
-
-                    <TextView
-                        android:id="@+id/carPrice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/price_per_day_format"
-                        android:textColor="#022B3A"
-                        android:textSize="15sp"
-                        android:textStyle="bold" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1" />
-
-                <!-- Availability Badge (optional) -->
-                <TextView
-                    android:id="@+id/carAvailability"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:paddingHorizontal="10dp"
-                    android:paddingVertical="4dp"
-                    android:text="@string/car_available"
-                    android:textColor="#FFFFFF"
-                    android:textSize="12sp"
-                    android:backgroundTint="#1F7A8C"
-                    android:background="@drawable/bg_badge_rounded"
-                    android:gravity="center"
-                    android:visibility="visible" />
-            </LinearLayout>
+            <TextView
+                android:id="@+id/carPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:fontFamily="sans-serif-medium"
+                android:text="@string/price_per_day_format"
+                android:textColor="@color/textColorPrimary"
+                android:textSize="16sp"
+                android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,6 +25,18 @@
     <color name="colorError">#B00020</color>
     <color name="colorOnError">@color/palette_white</color>
 
+    <color name="homeBackground">#F5F7FB</color>
+    <color name="homeHeroStart">#1F7A8C</color>
+    <color name="homeHeroEnd">#0E4F64</color>
+    <color name="homeCardStroke">#E3EAF4</color>
+    <color name="homeChipBackground">#F2F6FA</color>
+    <color name="homeChipStroke">#D6E2F0</color>
+    <color name="homeSearchBackground">#FFFFFFFF</color>
+    <color name="homeSearchStroke">#DFE6F0</color>
+    <color name="homeFilterDefaultBackground">#FFFFFFFF</color>
+    <color name="homeFilterStroke">#D6E2F0</color>
+    <color name="homeFilterRipple">#1F7A8C</color>
+
     <!-- Specific UI Element Colors -->
     <color name="textColorPrimary">@color/palette_dark_blue</color>
     <color name="textColorSecondary">#55022B3A</color> <!-- Dark blue with alpha -->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="home_horizontal_padding">20dp</dimen>
+    <dimen name="home_section_spacing">24dp</dimen>
+    <dimen name="home_filter_chip_stroke_width">1dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,10 @@
     <string name="submit_rental_request">Submit Rental Request</string>
     <string name="find_perfect_car">Find Your Perfect Car</string>
     <string name="choose_from_selection">Choose from our wide selection of vehicles</string>
+    <string name="home_tagline">Premium rides, simplified</string>
+    <string name="home_subtitle">Discover clean, well-maintained cars tailored to every journey.</string>
+    <string name="home_categories_title">Browse by category</string>
+    <string name="search_cars_hint">Search cars, models or trims</string>
     <string name="categories">Categories</string>
     <string name="all">All</string>
     <string name="suv">SUV</string>
@@ -59,6 +63,7 @@
     <string name="driver_license_label">Driver License:</string>
     <string name="car_available">Available</string>
     <string name="price_per_day_format">%.2f dhs / day</string>
+    <string name="car_image_content_description">Car preview</string>
     <string name="full_name">Full Name</string>
     <string name="email">Email</string>
     <string name="next">Next</string>


### PR DESCRIPTION
## Summary
- refresh the home fragment with a gradient hero card, minimalist search bar, and pill-shaped filters
- restyle car list items with softer cards, availability badges, and chip styling
- add supporting colors, dimens, and drawable resources for the streamlined look

## Testing
- sh gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5fc980e648333817414cb4c11631e