### PR TITLE
Redesign client home UI

### DIFF
--- a/app/src/main/res/drawable/bg_car_image_accent.xml
+++ b/app/src/main/res/drawable/bg_car_image_accent.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <gradient
+        android:startColor="#F0F7FA"
+        android:endColor="#FFFFFF"
+        android:angle="135" />
+</shape>

--- a/app/src/main/res/drawable/bg_home_header.xml
+++ b/app/src/main/res/drawable/bg_home_header.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                android:startColor="@color/homeHeroStart"
+                android:endColor="@color/homeHeroEnd"
+                android:angle="120" />
+            <corners
+                android:topLeftRadius="0dp"
+                android:topRightRadius="0dp"
+                android:bottomLeftRadius="36dp"
+                android:bottomRightRadius="36dp" />
+        </shape>
+    </item>
+    <item
+        android:gravity="end|top"
+        android:height="220dp"
+        android:width="220dp"
+        android:top="-48dp"
+        android:right="-48dp">
+        <shape android:shape="oval">
+            <solid android:color="#2FFFFFFF" />
+        </shape>
+    </item>
+    <item
+        android:gravity="end|bottom"
+        android:height="180dp"
+        android:width="180dp"
+        android:bottom="-24dp"
+        android:right="-24dp">
+        <shape android:shape="oval">
+            <solid android:color="#1AFFFFFF" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/ic_filter.xml
+++ b/app/src/main/res/drawable/ic_filter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18V6H3zm3,7h12v-2H6v2z" />
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,103 +1,206 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/homeBackground"
-    android:paddingHorizontal="@dimen/home_horizontal_padding"
-    android:paddingTop="@dimen/home_section_spacing"
-    android:paddingBottom="16dp">
+    android:background="@color/homeBackground">
 
-    <!-- Hero Section -->
+    <FrameLayout
+        android:id="@+id/headerContainer"
+        android:layout_width="0dp"
+        android:layout_height="280dp"
+        android:background="@drawable/bg_home_header"
+        android:clipToPadding="false"
+        android:paddingStart="@dimen/home_horizontal_padding"
+        android:paddingTop="36dp"
+        android:paddingEnd="@dimen/home_horizontal_padding"
+        android:paddingBottom="32dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/headerAccent"
+            android:layout_width="220dp"
+            android:layout_height="220dp"
+            android:layout_gravity="end|center_vertical"
+            android:alpha="0.18"
+            android:scaleType="centerInside"
+            android:src="@drawable/car_placeholder"
+            android:tint="@color/colorOnPrimary" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/heroTagline"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/home_tagline"
+                        android:textAllCaps="true"
+                        android:textColor="@color/colorOnPrimary"
+                        android:textSize="12sp"
+                        android:letterSpacing="0.12"
+                        android:fontFamily="sans-serif-medium" />
+
+                    <TextView
+                        android:id="@+id/heroTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:fontFamily="sans-serif-medium"
+                        android:text="@string/find_perfect_car"
+                        android:textColor="@color/colorOnPrimary"
+                        android:textSize="28sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_marginStart="12dp"
+                    app:cardBackgroundColor="#33FFFFFF"
+                    app:cardCornerRadius="16dp"
+                    app:cardElevation="0dp">
+
+                    <ImageView
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:padding="12dp"
+                        android:src="@drawable/ic_person"
+                        android:tint="@color/colorOnPrimary"
+                        android:contentDescription="@string/my_profile" />
+                </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/heroSubtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/home_subtitle"
+                android:textColor="@color/colorOnPrimary"
+                android:textSize="15sp"
+                android:alpha="0.9" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:background="@drawable/bg_badge_soft"
+                android:paddingStart="16dp"
+                android:paddingTop="10dp"
+                android:paddingEnd="20dp"
+                android:paddingBottom="10dp"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_marginEnd="8dp"
+                    android:src="@drawable/ic_car"
+                    android:tint="@color/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <TextView
+                    android:id="@+id/heroBadge"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/home_badge_text"
+                    android:textColor="@color/colorPrimary"
+                    android:textSize="13sp"
+                    android:fontFamily="sans-serif-medium" />
+            </LinearLayout>
+        </LinearLayout>
+    </FrameLayout>
+
     <com.google.android.material.card.MaterialCardView
-        android:layout_width="match_parent"
+        android:id="@+id/searchContainer"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="24dp"
-        app:cardBackgroundColor="@android:color/transparent"
-        app:cardCornerRadius="24dp"
-        app:cardElevation="0dp"
-        app:cardUseCompatPadding="false"
-        app:strokeWidth="0dp">
+        android:layout_marginStart="@dimen/home_horizontal_padding"
+        android:layout_marginEnd="@dimen/home_horizontal_padding"
+        android:translationY="-40dp"
+        app:cardBackgroundColor="@color/homeSearchBackground"
+        app:cardCornerRadius="20dp"
+        app:cardElevation="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/headerContainer">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/bg_home_hero"
-            android:orientation="vertical"
-            android:padding="24dp">
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="8dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp">
 
-            <TextView
-                android:id="@+id/heroTagline"
-                android:layout_width="wrap_content"
+            <androidx.appcompat.widget.SearchView
+                android:id="@+id/searchView"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/home_tagline"
-                android:textAllCaps="true"
-                android:textColor="@color/colorOnPrimary"
-                android:textSize="12sp"
-                android:letterSpacing="0.08"
-                android:fontFamily="sans-serif-medium" />
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:iconifiedByDefault="false"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:queryHint="@string/search_cars_hint"
+                app:queryBackground="@android:color/transparent" />
 
-            <TextView
-                android:id="@+id/heroTitle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:fontFamily="sans-serif-medium"
-                android:text="@string/find_perfect_car"
-                android:textColor="@color/colorOnPrimary"
-                android:textSize="24sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/heroSubtitle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:text="@string/home_subtitle"
-                android:textColor="@color/colorOnPrimary"
-                android:textSize="14sp"
-                android:alpha="0.85" />
+            <ImageButton
+                android:id="@+id/filterButton"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/home_filter_content_description"
+                android:padding="8dp"
+                android:src="@drawable/ic_filter"
+                android:tint="@color/colorPrimary" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 
-    <!-- Search -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="20dp"
-        android:background="@drawable/bg_search_bar"
-        android:gravity="center_vertical"
-        android:paddingHorizontal="12dp"
-        android:paddingVertical="6dp">
-
-        <androidx.appcompat.widget.SearchView
-            android:id="@+id/searchView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@android:color/transparent"
-            android:iconifiedByDefault="false"
-            android:queryHint="@string/search_cars_hint"
-            android:paddingHorizontal="4dp"
-            app:queryBackground="@android:color/transparent" />
-    </LinearLayout>
-
-    <!-- Category Filter -->
     <TextView
+        android:id="@+id/categoryTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
+        android:layout_marginStart="@dimen/home_horizontal_padding"
+        android:layout_marginTop="-8dp"
         android:text="@string/home_categories_title"
         android:textColor="@color/textColorPrimary"
         android:textSize="16sp"
-        android:textStyle="bold" />
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/searchContainer" />
 
     <HorizontalScrollView
-        android:layout_width="match_parent"
+        android:id="@+id/categoryScroll"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="20dp"
+        android:layout_marginStart="@dimen/home_horizontal_padding"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="@dimen/home_horizontal_padding"
         android:overScrollMode="never"
-        android:scrollbars="none">
+        android:scrollbars="none"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/categoryTitle">
 
         <LinearLayout
             android:id="@+id/filterContainer"
@@ -110,13 +213,17 @@
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="10dp"
+                android:layout_marginEnd="12dp"
                 android:text="@string/all"
                 android:textAllCaps="false"
                 android:textColor="@color/colorPrimary"
                 android:textSize="14sp"
                 app:backgroundTint="@color/homeFilterDefaultBackground"
                 app:cornerRadius="50dp"
+                app:icon="@drawable/ic_car"
+                app:iconGravity="textStart"
+                app:iconPadding="12dp"
+                app:iconTint="@color/colorPrimary"
                 app:strokeColor="@color/homeFilterStroke"
                 app:strokeWidth="1dp" />
 
@@ -125,13 +232,17 @@
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="10dp"
+                android:layout_marginEnd="12dp"
                 android:text="@string/suv"
                 android:textAllCaps="false"
                 android:textColor="@color/colorPrimary"
                 android:textSize="14sp"
                 app:backgroundTint="@color/homeFilterDefaultBackground"
                 app:cornerRadius="50dp"
+                app:icon="@drawable/ic_car"
+                app:iconGravity="textStart"
+                app:iconPadding="12dp"
+                app:iconTint="@color/colorPrimary"
                 app:strokeColor="@color/homeFilterStroke"
                 app:strokeWidth="1dp" />
 
@@ -140,13 +251,17 @@
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="10dp"
+                android:layout_marginEnd="12dp"
                 android:text="@string/compact"
                 android:textAllCaps="false"
                 android:textColor="@color/colorPrimary"
                 android:textSize="14sp"
                 app:backgroundTint="@color/homeFilterDefaultBackground"
                 app:cornerRadius="50dp"
+                app:icon="@drawable/ic_car"
+                app:iconGravity="textStart"
+                app:iconPadding="12dp"
+                app:iconTint="@color/colorPrimary"
                 app:strokeColor="@color/homeFilterStroke"
                 app:strokeWidth="1dp" />
 
@@ -161,20 +276,43 @@
                 android:textSize="14sp"
                 app:backgroundTint="@color/homeFilterDefaultBackground"
                 app:cornerRadius="50dp"
+                app:icon="@drawable/ic_car"
+                app:iconGravity="textStart"
+                app:iconPadding="12dp"
+                app:iconTint="@color/colorPrimary"
                 app:strokeColor="@color/homeFilterStroke"
                 app:strokeWidth="1dp" />
         </LinearLayout>
     </HorizontalScrollView>
 
-    <!-- ListView -->
+    <TextView
+        android:id="@+id/mostRentedTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/home_horizontal_padding"
+        android:layout_marginTop="28dp"
+        android:text="@string/home_most_rented_title"
+        android:textColor="@color/textColorPrimary"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/categoryScroll" />
+
     <ListView
         android:id="@+id/carsListView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_weight="1"
+        android:layout_marginStart="@dimen/home_horizontal_padding"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="@dimen/home_horizontal_padding"
+        android:layout_marginBottom="16dp"
         android:clipToPadding="false"
         android:divider="@android:color/transparent"
-        android:dividerHeight="16dp"
-        android:paddingBottom="8dp" />
+        android:dividerHeight="20dp"
+        android:paddingBottom="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mostRentedTitle" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_car.xml
+++ b/app/src/main/res/layout/item_car.xml
@@ -4,92 +4,123 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="4dp"
     android:foreground="?attr/selectableItemBackground"
     app:cardBackgroundColor="@color/colorSurface"
-    app:cardCornerRadius="20dp"
-    app:cardElevation="2dp"
+    app:cardCornerRadius="24dp"
+    app:cardElevation="6dp"
     app:cardUseCompatPadding="false"
     app:strokeColor="@color/homeCardStroke"
-    app:strokeWidth="1dp">
+    app:strokeWidth="0dp">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:padding="20dp">
 
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="180dp"
-            android:background="@color/homeChipBackground">
+        <TextView
+            android:id="@+id/carAvailability"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_badge_soft"
+            android:backgroundTint="@color/primary_blue"
+            android:fontFamily="sans-serif-medium"
+            android:paddingStart="14dp"
+            android:paddingTop="6dp"
+            android:paddingEnd="14dp"
+            android:paddingBottom="6dp"
+            android:text="@string/car_available"
+            android:textAllCaps="false"
+            android:textColor="@color/colorOnPrimary"
+            android:textSize="12sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageView
-                android:id="@+id/carImage"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:contentDescription="@string/car_image_content_description"
-                android:scaleType="centerCrop"
-                android:src="@drawable/ic_app_logo" />
+        <TextView
+            android:id="@+id/carModel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-medium"
+            android:maxLines="2"
+            android:text="@string/car_model"
+            android:textColor="@color/textColorPrimary"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@+id/imageAccent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/carAvailability" />
 
-            <TextView
-                android:id="@+id/carAvailability"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="start|top"
-                android:layout_margin="12dp"
-                android:background="@drawable/bg_badge_soft"
-                android:backgroundTint="@color/primary_blue"
-                android:gravity="center"
-                android:paddingHorizontal="12dp"
-                android:paddingVertical="6dp"
-                android:text="@string/car_available"
-                android:textAllCaps="false"
-                android:textColor="@color/colorOnPrimary"
-                android:textSize="12sp"
-                android:textStyle="bold"
-                android:visibility="visible" />
-        </FrameLayout>
+        <TextView
+            android:id="@+id/carType"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:background="@drawable/bg_chip_soft"
+            android:paddingStart="14dp"
+            android:paddingTop="6dp"
+            android:paddingEnd="14dp"
+            android:paddingBottom="6dp"
+            android:text="@string/suv"
+            android:textAllCaps="false"
+            android:textColor="@color/colorPrimary"
+            android:textSize="13sp"
+            app:layout_constraintStart_toStartOf="@id/carModel"
+            app:layout_constraintTop_toBottomOf="@id/carModel" />
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:id="@+id/priceRow"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="20dp">
+            android:layout_marginTop="20dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            app:layout_constraintStart_toStartOf="@id/carType"
+            app:layout_constraintTop_toBottomOf="@id/carType">
 
-            <TextView
-                android:id="@+id/carModel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:fontFamily="sans-serif-medium"
-                android:maxLines="1"
-                android:text="@string/car_model"
-                android:textColor="@color/textColorPrimary"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/carType"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:background="@drawable/bg_chip_soft"
-                android:paddingHorizontal="12dp"
-                android:paddingVertical="6dp"
-                android:text="@string/suv"
-                android:textAllCaps="false"
-                android:textColor="@color/colorPrimary"
-                android:textSize="13sp" />
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_price"
+                android:tint="@color/colorPrimary"
+                android:contentDescription="@null" />
 
             <TextView
                 android:id="@+id/carPrice"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
                 android:fontFamily="sans-serif-medium"
                 android:text="@string/price_per_day_format"
                 android:textColor="@color/textColorPrimary"
                 android:textSize="16sp"
                 android:textStyle="bold" />
         </LinearLayout>
-    </LinearLayout>
+
+        <View
+            android:id="@+id/imageAccent"
+            android:layout_width="140dp"
+            android:layout_height="140dp"
+            android:layout_marginStart="16dp"
+            android:background="@drawable/bg_car_image_accent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/carImage"
+            android:layout_width="150dp"
+            android:layout_height="120dp"
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/car_image_content_description"
+            android:scaleType="centerInside"
+            android:src="@drawable/car_placeholder"
+            app:layout_constraintBottom_toBottomOf="@id/imageAccent"
+            app:layout_constraintEnd_toEndOf="@id/imageAccent"
+            app:layout_constraintTop_toTopOf="@id/imageAccent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,10 @@
     <string name="choose_from_selection">Choose from our wide selection of vehicles</string>
     <string name="home_tagline">Premium rides, simplified</string>
     <string name="home_subtitle">Discover clean, well-maintained cars tailored to every journey.</string>
+    <string name="home_badge_text">Over 50+ verified cars ready for you</string>
     <string name="home_categories_title">Browse by category</string>
+    <string name="home_most_rented_title">Most rented</string>
+    <string name="home_filter_content_description">Open car filters</string>
     <string name="search_cars_hint">Search cars, models or trims</string>
     <string name="categories">Categories</string>
     <string name="all">All</string>


### PR DESCRIPTION
## Summary
- restyled the client home fragment with a modern hero header, floating search card, and refreshed category chips
- updated the car list item cards to showcase pricing and imagery in a cleaner layout
- added supporting drawables, icon, and copy for the new presentation

## Testing
- bash gradlew lint --console=plain *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d60171a2f48333b3f04c4e4dde29a7