### PR TITLE
Revamp home fragment UI for clients

### DIFF
--- a/app/src/main/res/drawable/ic_arrow_forward.xml
+++ b/app/src/main/res/drawable/ic_arrow_forward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,4l-1.41,1.41L16.17,11H4v2h12.17l-5.58,5.59L12,20l8,-8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_location.xml
+++ b/app/src/main/res/drawable/ic_location.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27A6.471,6.471 0,0 0,16 9.5C16,6.46 13.54,4 10.5,4S5,6.46 5,9.5 7.46,15 10.5,15c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l4.25,4.25c0.41,0.41 0.41,1.07 0,1.48 -0.41,0.41 -1.07,0.41 -1.48,0l-4.25,-4.25zM10.5,13C8.57,13 7,11.43 7,9.5S8.57,6 10.5,6 14,7.57 14,9.5 12.43,13 10.5,13z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -3,613 +3,942 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#F8F9FA">
+    android:background="@drawable/bg_home_background">
 
-    <!-- Header Section -->
-    <LinearLayout
-        android:id="@+id/headerSection"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/homeScroll"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:background="#4F46E5"
-        android:orientation="vertical"
-        android:padding="24dp"
-        android:paddingTop="48dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingBottom="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <!-- Top Bar -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:layout_marginBottom="20dp">
+            android:orientation="vertical"
+            android:paddingBottom="32dp">
 
-            <LinearLayout
-                android:layout_width="0dp"
+            <!-- Hero Header -->
+            <FrameLayout
+                android:id="@+id/heroContainer"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
+                android:background="@drawable/bg_home_header"
+                android:paddingStart="24dp"
+                android:paddingTop="60dp"
+                android:paddingEnd="24dp"
+                android:paddingBottom="44dp">
 
-                <TextView
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="PREMIUM RIDES, SIMPLIFIED"
-                    android:textColor="#FFFFFF"
-                    android:textSize="12sp"
-                    android:alpha="0.8"
-                    android:letterSpacing="0.1" />
+                    android:orientation="vertical">
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Find Your Perfect Car"
-                    android:textColor="#FFFFFF"
-                    android:textSize="28sp"
-                    android:textStyle="bold"
-                    android:layout_marginTop="8dp" />
-            </LinearLayout>
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
 
-            <View
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:background="#FFFFFF"
-                android:backgroundTint="#1AFFFFFF" />
-        </LinearLayout>
+                        <ImageView
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:background="@drawable/bg_profile_avatar"
+                            android:padding="12dp"
+                            android:src="@drawable/ic_person"
+                            android:tint="@color/colorPrimary"
+                            android:contentDescription="@string/app_name" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Discover clean, well-maintained cars tailored to every journey."
-            android:textColor="#FFFFFF"
-            android:textSize="16sp"
-            android:alpha="0.9"
-            android:layout_marginBottom="24dp" />
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="16dp"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
 
-        <!-- Membership Card -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="#FFFFFF"
-            android:backgroundTint="#1A FFFFFF"
-            android:padding="16dp"
-            android:orientation="horizontal"
-            android:gravity="center_vertical">
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:alpha="0.8"
+                                android:fontFamily="sans-serif-medium"
+                                android:text="@string/home_welcome_back"
+                                android:textColor="@android:color/white"
+                                android:textSize="12sp" />
 
-            <View
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:background="#FFD700"
-                android:layout_marginEnd="16dp" />
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="2dp"
+                                android:text="@string/home_subheadline"
+                                android:textColor="@android:color/white"
+                                android:textSize="18sp"
+                                android:textStyle="bold" />
+                        </LinearLayout>
 
-            <LinearLayout
-                android:layout_width="0dp"
+                        <ImageButton
+                            android:id="@+id/filterButton"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:background="@drawable/bg_badge_soft"
+                            android:contentDescription="@string/home_filter_content_description"
+                            android:padding="8dp"
+                            android:src="@drawable/ic_filter"
+                            android:tint="@color/colorPrimary" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="32dp"
+                        android:text="@string/home_hero_title"
+                        android:textColor="@android:color/white"
+                        android:textSize="26sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:alpha="0.85"
+                        android:text="@string/home_hero_caption"
+                        android:textColor="@android:color/white"
+                        android:textSize="14sp" />
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="28dp"
+                        android:layout_marginEnd="8dp"
+                        android:layout_marginStart="8dp"
+                        android:foreground="?attr/selectableItemBackground"
+                        app:cardBackgroundColor="@android:color/transparent"
+                        app:cardCornerRadius="20dp"
+                        app:strokeColor="@color/homeHighlightStroke"
+                        app:strokeWidth="1dp">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@drawable/bg_home_highlight_card"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal">
+
+                            <ImageView
+                                android:layout_width="40dp"
+                                android:layout_height="40dp"
+                                android:layout_marginEnd="16dp"
+                                android:src="@drawable/ic_card_membership"
+                                android:tint="@color/homeHighlightTitle"
+                                android:contentDescription="@null" />
+
+                            <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/home_highlight_title"
+                                    android:textColor="@color/homeHighlightTitle"
+                                    android:textSize="16sp"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="4dp"
+                                    android:text="@string/home_highlight_subtitle"
+                                    android:textColor="@color/homeHighlightSubtitle"
+                                    android:textSize="13sp" />
+                            </LinearLayout>
+
+                            <ImageView
+                                android:layout_width="32dp"
+                                android:layout_height="32dp"
+                                android:layout_marginStart="12dp"
+                                android:src="@drawable/ic_arrow_forward"
+                                android:tint="@color/homeHighlightTitle"
+                                android:contentDescription="@null" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+                </LinearLayout>
+            </FrameLayout>
+
+            <!-- Search Card -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/searchCard"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
+                android:layout_marginStart="24dp"
+                android:layout_marginTop="-36dp"
+                android:layout_marginEnd="24dp"
+                android:elevation="8dp"
+                android:foreground="?attr/selectableItemBackground"
+                app:cardBackgroundColor="@color/homeSearchBackground"
+                app:cardCornerRadius="24dp"
+                app:cardElevation="0dp"
+                app:strokeColor="@color/homeSearchStroke"
+                app:strokeWidth="1dp">
 
-                <TextView
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Member-exclusive curation"
-                    android:textColor="#000000"
-                    android:textSize="15sp"
-                    android:textStyle="bold" />
+                    android:orientation="vertical"
+                    android:padding="20dp">
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Hand-picked models from our concierge"
-                    android:textColor="#000000"
-                    android:textSize="12sp"
-                    android:alpha="0.8"
-                    android:layout_marginTop="2dp" />
-            </LinearLayout>
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
 
-            <View
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:background="#FFFFFF"
-                android:backgroundTint="#33FFFFFF" />
-        </LinearLayout>
-    </LinearLayout>
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:contentDescription="@string/search_field_hint"
+                            android:src="@drawable/ic_search"
+                            android:tint="@color/iconTint" />
 
-    <!-- Search Section -->
-    <LinearLayout
-        android:id="@+id/searchSection"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="-40dp"
-        android:layout_marginEnd="20dp"
-        android:background="#FFFFFF"
-        android:elevation="8dp"
-        android:orientation="vertical"
-        android:padding="20dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/headerSection">
+                        <EditText
+                            android:id="@+id/searchEditText"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:layout_weight="1"
+                            android:background="@android:color/transparent"
+                            android:hint="@string/search_field_hint"
+                            android:imeOptions="actionSearch"
+                            android:inputType="text"
+                            android:padding="0dp"
+                            android:textColor="@color/textColorPrimary"
+                            android:textSize="15sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Search Cars"
-            android:textColor="#1F2937"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:layout_marginBottom="12dp" />
+                        <ImageButton
+                            android:id="@+id/voiceSearchButton"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:background="@drawable/bg_badge_soft"
+                            android:contentDescription="@string/search_field_hint"
+                            android:padding="8dp"
+                            android:src="@drawable/ic_send"
+                            android:tint="@color/colorPrimary" />
+                    </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="56dp"
-            android:background="#F3F4F6"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingStart="16dp"
-            android:paddingEnd="8dp">
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginVertical="18dp"
+                        android:background="@color/homeSearchStroke" />
 
-            <EditText
-                android:id="@+id/searchEditText"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:background="@android:color/transparent"
-                android:hint="Search by model, brand, or type..."
-                android:textSize="14sp"
-                android:inputType="text" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="horizontal">
 
-            <View
-                android:layout_width="1dp"
-                android:layout_height="24dp"
-                android:layout_marginHorizontal="8dp"
-                android:background="#D1D5DB" />
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal">
 
-            <View
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:background="#4F46E5"
-                android:foreground="?attr/selectableItemBackgroundBorderless" />
-        </LinearLayout>
-    </LinearLayout>
+                            <ImageView
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:src="@drawable/ic_location"
+                                android:tint="@color/iconTint"
+                                android:contentDescription="@null" />
 
-    <!-- Categories Section -->
-    <LinearLayout
-        android:id="@+id/categoriesSection"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginEnd="20dp"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchSection">
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="8dp"
+                                android:text="@string/search_trip_pickup"
+                                android:textColor="@color/textColorSecondary"
+                                android:textSize="13sp" />
+                        </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:layout_marginBottom="16dp">
+                        <View
+                            android:layout_width="1dp"
+                            android:layout_height="24dp"
+                            android:background="@color/homeSearchStroke" />
 
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Browse by Category"
-                android:textColor="#1F2937"
-                android:textSize="20sp"
-                android:textStyle="bold" />
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:paddingStart="16dp">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="View All"
-                android:textColor="#4F46E5"
-                android:textSize="14sp"
-                android:textStyle="bold"
-                android:padding="8dp"
-                android:foreground="?attr/selectableItemBackgroundBorderless" />
-        </LinearLayout>
+                            <ImageView
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:src="@drawable/ic_calendar"
+                                android:tint="@color/iconTint"
+                                android:contentDescription="@null" />
 
-        <!-- Category Grid -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="8dp"
+                                android:text="@string/search_trip_dates"
+                                android:textColor="@color/textColorSecondary"
+                                android:textSize="13sp" />
+                        </LinearLayout>
 
-            <!-- First Row -->
+                        <View
+                            android:layout_width="1dp"
+                            android:layout_height="24dp"
+                            android:background="@color/homeSearchStroke" />
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:paddingStart="16dp">
+
+                            <ImageView
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:src="@drawable/ic_type"
+                                android:tint="@color/iconTint"
+                                android:contentDescription="@null" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="8dp"
+                                android:text="@string/search_trip_vehicle"
+                                android:textColor="@color/textColorSecondary"
+                                android:textSize="13sp" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- Quick Filters -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:layout_marginBottom="12dp">
+                android:layout_marginTop="32dp"
+                android:orientation="vertical"
+                android:paddingStart="24dp"
+                android:paddingEnd="24dp">
 
-                <!-- All Cars -->
-                <LinearLayout
-                    android:id="@+id/categoryAll"
-                    android:layout_width="0dp"
-                    android:layout_height="80dp"
-                    android:layout_weight="1"
-                    android:layout_marginEnd="8dp"
-                    android:background="#EFF6FF"
-                    android:elevation="2dp"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal"
-                    android:padding="16dp"
-                    android:foreground="?attr/selectableItemBackground">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/home_quick_filters"
+                    android:textColor="@color/textColorPrimary"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-                    <View
-                        android:layout_width="32dp"
-                        android:layout_height="32dp"
-                        android:background="#3B82F6"
-                        android:layout_marginEnd="12dp" />
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/filterChips"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:chipSpacingHorizontal="12dp"
+                    android:chipSpacingVertical="12dp"
+                    app:singleLine="false">
 
-                    <LinearLayout
-                        android:layout_width="0dp"
+                    <com.google.android.material.chip.Chip
+                        style="@style/Widget.MaterialComponents.Chip.Filter"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
+                        android:text="@string/filter_suv_getaways"
+                        android:textColor="@color/textColorPrimary"
+                        app:chipBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:chipIcon="@drawable/ic_car"
+                        app:chipIconTint="@color/colorSecondary"
+                        app:chipStrokeColor="@color/homeFilterStroke"
+                        app:chipStrokeWidth="1dp" />
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="All"
-                            android:textColor="#1E3A8A"
-                            android:textSize="14sp"
-                            android:textStyle="bold" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="250+ cars"
-                            android:textColor="#1E3A8A"
-                            android:textSize="12sp"
-                            android:alpha="0.7" />
-                    </LinearLayout>
-                </LinearLayout>
-
-                <!-- SUV -->
-                <LinearLayout
-                    android:id="@+id/categorySUV"
-                    android:layout_width="0dp"
-                    android:layout_height="80dp"
-                    android:layout_weight="1"
-                    android:layout_marginStart="8dp"
-                    android:background="#FEF3C7"
-                    android:elevation="2dp"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal"
-                    android:padding="16dp"
-                    android:foreground="?attr/selectableItemBackground">
-
-                    <View
-                        android:layout_width="32dp"
-                        android:layout_height="32dp"
-                        android:background="#F59E0B"
-                        android:layout_marginEnd="12dp" />
-
-                    <LinearLayout
-                        android:layout_width="0dp"
+                    <com.google.android.material.chip.Chip
+                        style="@style/Widget.MaterialComponents.Chip.Filter"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
+                        android:text="@string/filter_under_price_daily"
+                        android:textColor="@color/textColorPrimary"
+                        app:chipBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:chipIcon="@drawable/ic_price"
+                        app:chipIconTint="@color/colorSecondary"
+                        app:chipStrokeColor="@color/homeFilterStroke"
+                        app:chipStrokeWidth="1dp" />
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="SUV"
-                            android:textColor="#92400E"
-                            android:textSize="14sp"
-                            android:textStyle="bold" />
+                    <com.google.android.material.chip.Chip
+                        style="@style/Widget.MaterialComponents.Chip.Filter"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/filter_long_trips"
+                        android:textColor="@color/textColorPrimary"
+                        app:chipBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:chipIcon="@drawable/ic_calendar"
+                        app:chipIconTint="@color/colorSecondary"
+                        app:chipStrokeColor="@color/homeFilterStroke"
+                        app:chipStrokeWidth="1dp" />
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="85 cars"
-                            android:textColor="#92400E"
-                            android:textSize="12sp"
-                            android:alpha="0.7" />
-                    </LinearLayout>
-                </LinearLayout>
+                    <com.google.android.material.chip.Chip
+                        style="@style/Widget.MaterialComponents.Chip.Filter"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/filter_electric"
+                        android:textColor="@color/textColorPrimary"
+                        app:chipBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:chipIcon="@drawable/ic_type"
+                        app:chipIconTint="@color/colorSecondary"
+                        app:chipStrokeColor="@color/homeFilterStroke"
+                        app:chipStrokeWidth="1dp" />
+                </com.google.android.material.chip.ChipGroup>
             </LinearLayout>
 
-            <!-- Second Row -->
+            <!-- Categories Section -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:layout_marginTop="28dp"
+                android:orientation="vertical"
+                android:paddingStart="24dp"
+                android:paddingEnd="24dp">
 
-                <!-- Compact -->
                 <LinearLayout
-                    android:id="@+id/categoryCompact"
-                    android:layout_width="0dp"
-                    android:layout_height="80dp"
-                    android:layout_weight="1"
-                    android:layout_marginEnd="8dp"
-                    android:background="#ECFDF5"
-                    android:elevation="2dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:gravity="center_vertical"
-                    android:orientation="horizontal"
-                    android:padding="16dp"
-                    android:foreground="?attr/selectableItemBackground">
+                    android:orientation="horizontal">
 
-                    <View
-                        android:layout_width="32dp"
-                        android:layout_height="32dp"
-                        android:background="#10B981"
-                        android:layout_marginEnd="12dp" />
-
-                    <LinearLayout
+                    <TextView
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical">
+                        android:text="@string/home_popular_categories"
+                        android:textColor="@color/textColorPrimary"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Compact"
-                            android:textColor="#065F46"
-                            android:textSize="14sp"
-                            android:textStyle="bold" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="120 cars"
-                            android:textColor="#065F46"
-                            android:textSize="12sp"
-                            android:alpha="0.7" />
-                    </LinearLayout>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/action_view_all"
+                        android:textColor="@color/colorSecondary"
+                        android:textStyle="bold" />
                 </LinearLayout>
 
-                <!-- Luxury -->
-                <LinearLayout
-                    android:id="@+id/categoryLuxury"
-                    android:layout_width="0dp"
-                    android:layout_height="80dp"
-                    android:layout_weight="1"
-                    android:layout_marginStart="8dp"
-                    android:background="#FDF2F8"
-                    android:elevation="2dp"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal"
-                    android:padding="16dp"
-                    android:foreground="?attr/selectableItemBackground">
+                <androidx.gridlayout.widget.GridLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:columnCount="2"
+                    android:layout_marginTop="20dp"
+                    android:rowCount="2"
+                    android:useDefaultMargins="false">
 
-                    <View
-                        android:layout_width="32dp"
-                        android:layout_height="32dp"
-                        android:background="#EC4899"
-                        android:layout_marginEnd="12dp" />
-
-                    <LinearLayout
+                    <com.google.android.material.card.MaterialCardView
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
+                        android:layout_margin="8dp"
+                        app:layout_columnWeight="1"
+                        android:foreground="?attr/selectableItemBackground"
+                        app:cardBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:cardCornerRadius="18dp"
+                        app:strokeColor="@color/homeFilterStroke"
+                        app:strokeWidth="1dp">
 
-                        <TextView
-                            android:layout_width="wrap_content"
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="Luxury"
-                            android:textColor="#831843"
-                            android:textSize="14sp"
-                            android:textStyle="bold" />
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:padding="18dp">
 
-                        <TextView
-                            android:layout_width="wrap_content"
+                            <ImageView
+                                android:layout_width="32dp"
+                                android:layout_height="32dp"
+                                android:src="@drawable/ic_car"
+                                android:tint="@color/colorSecondary"
+                                android:contentDescription="@null" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="16dp"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/category_all_cars"
+                                    android:textColor="@color/textColorPrimary"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="4dp"
+                                    android:text="@string/category_all_cars_meta"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="12sp" />
+                            </LinearLayout>
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="8dp"
+                        app:layout_columnWeight="1"
+                        android:foreground="?attr/selectableItemBackground"
+                        app:cardBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:cardCornerRadius="18dp"
+                        app:strokeColor="@color/homeFilterStroke"
+                        app:strokeWidth="1dp">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="45 cars"
-                            android:textColor="#831843"
-                            android:textSize="12sp"
-                            android:alpha="0.7" />
-                    </LinearLayout>
-                </LinearLayout>
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:padding="18dp">
+
+                            <ImageView
+                                android:layout_width="32dp"
+                                android:layout_height="32dp"
+                                android:src="@drawable/ic_type"
+                                android:tint="@color/colorSecondary"
+                                android:contentDescription="@null" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="16dp"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/category_suv_adventures"
+                                    android:textColor="@color/textColorPrimary"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="4dp"
+                                    android:text="@string/category_suv_adventures_meta"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="12sp" />
+                            </LinearLayout>
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="8dp"
+                        app:layout_columnWeight="1"
+                        android:foreground="?attr/selectableItemBackground"
+                        app:cardBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:cardCornerRadius="18dp"
+                        app:strokeColor="@color/homeFilterStroke"
+                        app:strokeWidth="1dp">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:padding="18dp">
+
+                            <ImageView
+                                android:layout_width="32dp"
+                                android:layout_height="32dp"
+                                android:src="@drawable/ic_calendar"
+                                android:tint="@color/colorSecondary"
+                                android:contentDescription="@null" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="16dp"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/category_weekend_ready"
+                                    android:textColor="@color/textColorPrimary"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="4dp"
+                                    android:text="@string/category_weekend_ready_meta"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="12sp" />
+                            </LinearLayout>
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="8dp"
+                        app:layout_columnWeight="1"
+                        android:foreground="?attr/selectableItemBackground"
+                        app:cardBackgroundColor="@color/homeFilterDefaultBackground"
+                        app:cardCornerRadius="18dp"
+                        app:strokeColor="@color/homeFilterStroke"
+                        app:strokeWidth="1dp">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:padding="18dp">
+
+                            <ImageView
+                                android:layout_width="32dp"
+                                android:layout_height="32dp"
+                                android:src="@drawable/ic_price"
+                                android:tint="@color/colorSecondary"
+                                android:contentDescription="@null" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="16dp"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/category_business_class"
+                                    android:textColor="@color/textColorPrimary"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="4dp"
+                                    android:text="@string/category_business_class_meta"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="12sp" />
+                            </LinearLayout>
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+                </androidx.gridlayout.widget.GridLayout>
             </LinearLayout>
-        </LinearLayout>
-    </LinearLayout>
 
-    <!-- Most Rented Section -->
-    <LinearLayout
-        android:id="@+id/mostRentedSection"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="20dp"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/categoriesSection">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:layout_marginBottom="16dp">
-
+            <!-- Featured Rides -->
             <LinearLayout
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Most Rented"
-                    android:textColor="#1F2937"
-                    android:textSize="20sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Popular choices this week"
-                    android:textColor="#6B7280"
-                    android:textSize="14sp"
-                    android:layout_marginTop="2dp" />
-            </LinearLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="See All"
-                android:textColor="#4F46E5"
-                android:textSize="14sp"
-                android:textStyle="bold"
-                android:padding="8dp"
-                android:foreground="?attr/selectableItemBackgroundBorderless" />
-        </LinearLayout>
-
-        <!-- Sample Car Items -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="#FFFFFF"
-            android:elevation="2dp"
-            android:orientation="horizontal"
-            android:padding="16dp"
-            android:layout_marginBottom="12dp"
-            android:foreground="?attr/selectableItemBackground">
-
-            <View
-                android:layout_width="80dp"
-                android:layout_height="60dp"
-                android:background="#E5E7EB"
-                android:layout_marginEnd="16dp" />
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Tesla Model 3"
-                    android:textColor="#1F2937"
-                    android:textSize="16sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Electric • Automatic"
-                    android:textColor="#6B7280"
-                    android:textSize="14sp"
-                    android:layout_marginTop="4dp" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="$89/day"
-                    android:textColor="#4F46E5"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:layout_marginTop="8dp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
                 android:orientation="vertical"
-                android:gravity="end">
+                android:paddingStart="24dp"
+                android:paddingEnd="24dp">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="4.8 ★"
-                    android:textColor="#F59E0B"
-                    android:textSize="14sp"
+                    android:text="@string/home_featured_rides"
+                    android:textColor="@color/textColorPrimary"
+                    android:textSize="18sp"
                     android:textStyle="bold" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Available"
-                    android:textColor="#10B981"
-                    android:textSize="12sp"
-                    android:layout_marginTop="4dp" />
+                    android:layout_marginTop="4dp"
+                    android:text="@string/home_featured_rides_subtitle"
+                    android:textColor="@color/textColorSecondary"
+                    android:textSize="13sp" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:foreground="?attr/selectableItemBackground"
+                    app:cardBackgroundColor="@android:color/transparent"
+                    app:cardCornerRadius="24dp"
+                    app:strokeColor="@color/homeCardStroke"
+                    app:strokeWidth="1dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/bg_car_card"
+                        android:padding="20dp">
+
+                        <ImageView
+                            android:id="@+id/featuredCarImage"
+                            android:layout_width="0dp"
+                            android:layout_height="180dp"
+                            android:layout_marginEnd="16dp"
+                            android:contentDescription="@string/car_image_content_description"
+                            android:scaleType="centerCrop"
+                            android:src="@drawable/car_placeholder"
+                            app:layout_constraintEnd_toStartOf="@+id/featuredDetails"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintWidth_percent="0.4" />
+
+                        <LinearLayout
+                            android:id="@+id/featuredDetails"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/featuredCarImage"
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Tesla Model 3"
+                                android:textColor="@color/textColorPrimary"
+                                android:textSize="20sp"
+                                android:textStyle="bold" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="8dp"
+                                android:gravity="center_vertical"
+                                android:orientation="horizontal">
+
+                                <ImageView
+                                    android:layout_width="18dp"
+                                    android:layout_height="18dp"
+                                    android:src="@drawable/ic_type"
+                                    android:tint="@color/colorSecondary"
+                                    android:contentDescription="@null" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="6dp"
+                                    android:text="Electric"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="13sp" />
+
+                                <ImageView
+                                    android:layout_width="18dp"
+                                    android:layout_height="18dp"
+                                    android:layout_marginStart="16dp"
+                                    android:src="@drawable/ic_person"
+                                    android:tint="@color/colorSecondary"
+                                    android:contentDescription="@null" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="6dp"
+                                    android:text="4 seats"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="13sp" />
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="12dp"
+                                android:text="Autopilot • 280mi range"
+                                android:textColor="@color/textColorSecondary"
+                                android:textSize="13sp" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="16dp"
+                                android:gravity="center_vertical"
+                                android:orientation="horizontal">
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="$89/day"
+                                    android:textColor="@color/colorSecondary"
+                                    android:textSize="18sp"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="12dp"
+                                    android:text="4.8 ★"
+                                    android:textColor="@color/colorSecondary"
+                                    android:textSize="14sp" />
+                            </LinearLayout>
+
+                            <com.google.android.material.button.MaterialButton
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="18dp"
+                                android:text="@string/reserve"
+                                android:textAllCaps="false"
+                                android:textStyle="bold"
+                                app:backgroundTint="@color/colorPrimary"
+                                app:icon="@drawable/ic_car"
+                                app:iconPadding="8dp"
+                                app:iconTint="@android:color/white"
+                                app:rippleColor="@color/homeFilterRipple"
+                                app:strokeColor="@color/homeCardStroke"
+                                app:strokeWidth="0dp" />
+                        </LinearLayout>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:foreground="?attr/selectableItemBackground"
+                    app:cardBackgroundColor="@android:color/transparent"
+                    app:cardCornerRadius="24dp"
+                    app:strokeColor="@color/homeCardStroke"
+                    app:strokeWidth="1dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/bg_car_card"
+                        android:padding="20dp">
+
+                        <ImageView
+                            android:id="@+id/featuredCarImage2"
+                            android:layout_width="0dp"
+                            android:layout_height="180dp"
+                            android:layout_marginEnd="16dp"
+                            android:contentDescription="@string/car_image_content_description"
+                            android:scaleType="centerCrop"
+                            android:src="@drawable/car_placeholder"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@+id/featuredDetails2"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintWidth_percent="0.4" />
+
+                        <LinearLayout
+                            android:id="@+id/featuredDetails2"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/featuredCarImage2"
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Range Rover Evoque"
+                                android:textColor="@color/textColorPrimary"
+                                android:textSize="20sp"
+                                android:textStyle="bold" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="8dp"
+                                android:gravity="center_vertical"
+                                android:orientation="horizontal">
+
+                                <ImageView
+                                    android:layout_width="18dp"
+                                    android:layout_height="18dp"
+                                    android:src="@drawable/ic_type"
+                                    android:tint="@color/colorSecondary"
+                                    android:contentDescription="@null" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="6dp"
+                                    android:text="SUV"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="13sp" />
+
+                                <ImageView
+                                    android:layout_width="18dp"
+                                    android:layout_height="18dp"
+                                    android:layout_marginStart="16dp"
+                                    android:src="@drawable/ic_person"
+                                    android:tint="@color/colorSecondary"
+                                    android:contentDescription="@null" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="6dp"
+                                    android:text="5 seats"
+                                    android:textColor="@color/textColorSecondary"
+                                    android:textSize="13sp" />
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="12dp"
+                                android:text="Panoramic roof • Luxe interior"
+                                android:textColor="@color/textColorSecondary"
+                                android:textSize="13sp" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="16dp"
+                                android:gravity="center_vertical"
+                                android:orientation="horizontal">
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="$125/day"
+                                    android:textColor="@color/colorSecondary"
+                                    android:textSize="18sp"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="12dp"
+                                    android:text="4.9 ★"
+                                    android:textColor="@color/colorSecondary"
+                                    android:textSize="14sp" />
+                            </LinearLayout>
+
+                            <com.google.android.material.button.MaterialButton
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="18dp"
+                                android:text="@string/reserve"
+                                android:textAllCaps="false"
+                                android:textStyle="bold"
+                                app:backgroundTint="@color/colorPrimary"
+                                app:icon="@drawable/ic_car"
+                                app:iconPadding="8dp"
+                                app:iconTint="@android:color/white"
+                                app:rippleColor="@color/homeFilterRipple"
+                                app:strokeColor="@color/homeCardStroke"
+                                app:strokeWidth="0dp" />
+                        </LinearLayout>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
         </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="#FFFFFF"
-            android:elevation="2dp"
-            android:orientation="horizontal"
-            android:padding="16dp"
-            android:layout_marginBottom="24dp"
-            android:foreground="?attr/selectableItemBackground">
-
-            <View
-                android:layout_width="80dp"
-                android:layout_height="60dp"
-                android:background="#E5E7EB"
-                android:layout_marginEnd="16dp" />
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="BMW X5"
-                    android:textColor="#1F2937"
-                    android:textSize="16sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="SUV • Automatic"
-                    android:textColor="#6B7280"
-                    android:textSize="14sp"
-                    android:layout_marginTop="4dp" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="$125/day"
-                    android:textColor="#4F46E5"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:layout_marginTop="8dp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:gravity="end">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="4.9 ★"
-                    android:textColor="#F59E0B"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Available"
-                    android:textColor="#10B981"
-                    android:textSize="12sp"
-                    android:layout_marginTop="4dp" />
-            </LinearLayout>
-        </LinearLayout>
-    </LinearLayout>
-
+    </androidx.core.widget.NestedScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,36 @@
     <string name="home_most_rented_title">Most rented</string>
     <string name="home_filter_content_description">Open car filters</string>
     <string name="search_cars_hint">Search cars, models or trims</string>
+
+    <!-- Refreshed home experience strings -->
+    <string name="home_welcome_back">Welcome back</string>
+    <string name="home_subheadline">Plan your next drive</string>
+    <string name="home_hero_title">Find the right car for every journey</string>
+    <string name="home_hero_caption">Exclusive fleet, premium support and seamless verification</string>
+    <string name="home_highlight_title">Member concierge</string>
+    <string name="home_highlight_subtitle">Personalized car recommendations and priority pick-up</string>
+    <string name="home_quick_filters">Quick filters</string>
+    <string name="filter_suv_getaways">SUV getaways</string>
+    <string name="filter_under_price_daily">Under $90/day</string>
+    <string name="filter_long_trips">Long trips</string>
+    <string name="filter_electric">Electric</string>
+    <string name="home_popular_categories">Popular categories</string>
+    <string name="action_view_all">View all</string>
+    <string name="category_all_cars">All cars</string>
+    <string name="category_all_cars_meta">+250 in stock</string>
+    <string name="category_suv_adventures">SUV adventures</string>
+    <string name="category_suv_adventures_meta">85 options</string>
+    <string name="category_weekend_ready">Weekend ready</string>
+    <string name="category_weekend_ready_meta">Flexible return</string>
+    <string name="category_business_class">Business class</string>
+    <string name="category_business_class_meta">Premium sedans</string>
+    <string name="home_featured_rides">Featured rides</string>
+    <string name="home_featured_rides_subtitle">Curated picks loved by our community</string>
+    <string name="search_field_hint">Search by model, brand or experience</string>
+    <string name="search_trip_pickup">Pick-up</string>
+    <string name="search_trip_dates">Dates</string>
+    <string name="search_trip_vehicle">Vehicle</string>
+    <string name="reserve">Reserve</string>
     <string name="categories">Categories</string>
     <string name="all">All</string>
     <string name="suv">SUV</string>


### PR DESCRIPTION
## Summary
- redesign the client home fragment with a modern hero header, search card, quick filters, category grid, and featured rides sections
- add supporting string resources and vector icons used throughout the refreshed layout

## Testing
- ./gradlew lint *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83c9b722883338a71640dea1b7f66