### PR TITLE
Fix crash on login by restoring home car list view

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -474,6 +474,33 @@
                 </com.google.android.material.chip.ChipGroup>
             </LinearLayout>
 
+            <TextView
+                android:id="@+id/tvAvailableCars"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/home_horizontal_padding"
+                android:layout_marginEnd="@dimen/home_horizontal_padding"
+                android:layout_marginTop="24dp"
+                android:text="@string/home_available_cars"
+                android:textColor="@color/textColorPrimary"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <ListView
+                android:id="@+id/carsListView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/home_horizontal_padding"
+                android:layout_marginEnd="@dimen/home_horizontal_padding"
+                android:layout_marginTop="12dp"
+                android:divider="@null"
+                android:dividerHeight="16dp"
+                android:listSelector="@android:color/transparent"
+                android:nestedScrollingEnabled="true"
+                android:paddingBottom="8dp"
+                android:clipToPadding="false"
+                android:scrollbars="none" />
+
             <!-- Categories Section -->
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -58,6 +58,7 @@
     <string name="phone_label">الهاتف:</string>
     <string name="driver_license_label">رخصة القيادة:</string>
     <string name="car_available">متاح</string>
+    <string name="home_available_cars">المركبات المتاحة</string>
     <string name="price_per_day_format">%.2f درهم / اليوم</string>
     <string name="full_name">الاسم الكامل</string>
     <string name="email">البريد الإلكتروني</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,6 +58,7 @@
     <string name="phone_label">Téléphone :</string>
     <string name="driver_license_label">Permis de conduire :</string>
     <string name="car_available">Disponible</string>
+    <string name="home_available_cars">Véhicules disponibles</string>
     <string name="price_per_day_format">%.2f dhs / jour</string>
     <string name="full_name">Nom complet</string>
     <string name="email">E-mail</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="category_weekend_ready_meta">Flexible return</string>
     <string name="category_business_class">Business class</string>
     <string name="category_business_class_meta">Premium sedans</string>
+    <string name="home_available_cars">Available vehicles</string>
     <string name="home_featured_rides">Featured rides</string>
     <string name="home_featured_rides_subtitle">Curated picks loved by our community</string>
     <string name="search_field_hint">Search by model, brand or experience</string>


### PR DESCRIPTION
## Summary
- add the missing available cars section to the home layout so the fragment can find its list view
- introduce a localized "available vehicles" heading for the new list section

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d866783074833397736431168163ed