### PR TITLE
Revamp home UI and extend car details

### DIFF
--- a/app/src/main/java/com/example/carrentingtest/adapters/CarAdapter.java
+++ b/app/src/main/java/com/example/carrentingtest/adapters/CarAdapter.java
@@ -29,6 +29,8 @@ public class CarAdapter extends ArrayAdapter<Car> {
         ImageView carImage;
         TextView carModel;
         TextView carType;
+        TextView carTransmission;
+        TextView carSeats;
         TextView carPrice;
         TextView carAvailability;
     }
@@ -45,6 +47,8 @@ public class CarAdapter extends ArrayAdapter<Car> {
             holder.carImage = convertView.findViewById(R.id.carImage);
             holder.carModel = convertView.findViewById(R.id.carModel);
             holder.carType = convertView.findViewById(R.id.carType);
+            holder.carTransmission = convertView.findViewById(R.id.carTransmission);
+            holder.carSeats = convertView.findViewById(R.id.carSeats);
             holder.carPrice = convertView.findViewById(R.id.carPrice);
             holder.carAvailability = convertView.findViewById(R.id.carAvailability);
 
@@ -57,6 +61,18 @@ public class CarAdapter extends ArrayAdapter<Car> {
             // Set texts
             holder.carModel.setText(car.getModel());
             holder.carType.setText(car.getType());
+
+            String transmission = car.getTransmissionType();
+            if (transmission == null || transmission.trim().isEmpty()) {
+                transmission = getContext().getString(R.string.transmission_unknown);
+            }
+            holder.carTransmission.setText(transmission);
+
+            int seats = car.getSeats();
+            String seatsText = seats > 0
+                    ? getContext().getResources().getQuantityString(R.plurals.car_seats_count, seats, seats)
+                    : getContext().getString(R.string.seats_unknown);
+            holder.carSeats.setText(seatsText);
 
             // Format price
             holder.carPrice.setText(String.format(getContext().getString(R.string.price_per_day_format), car.getPricePerDay()));

--- a/app/src/main/java/com/example/carrentingtest/adapters/CarGridAdapter.java
+++ b/app/src/main/java/com/example/carrentingtest/adapters/CarGridAdapter.java
@@ -1,0 +1,123 @@
+package com.example.carrentingtest.adapters;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.example.carrentingtest.R;
+import com.example.carrentingtest.models.Car;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.card.MaterialCardView;
+
+import java.util.List;
+
+public class CarGridAdapter extends RecyclerView.Adapter<CarGridAdapter.CarViewHolder> {
+
+    public interface OnCarClickListener {
+        void onCarClicked(Car car);
+    }
+
+    private final List<Car> cars;
+    private final OnCarClickListener listener;
+
+    public CarGridAdapter(List<Car> cars, OnCarClickListener listener) {
+        this.cars = cars;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public CarViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_car, parent, false);
+        return new CarViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull CarViewHolder holder, int position) {
+        Car car = cars.get(position);
+        holder.bind(car, listener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return cars.size();
+    }
+
+    static class CarViewHolder extends RecyclerView.ViewHolder {
+
+        private final ImageView carImage;
+        private final TextView carModel;
+        private final TextView carType;
+        private final TextView carTransmission;
+        private final TextView carSeats;
+        private final TextView carPrice;
+        private final TextView carAvailability;
+        private final MaterialButton rentButton;
+        private final MaterialCardView rootCard;
+
+        CarViewHolder(@NonNull View itemView) {
+            super(itemView);
+            carImage = itemView.findViewById(R.id.carImage);
+            carModel = itemView.findViewById(R.id.carModel);
+            carType = itemView.findViewById(R.id.carType);
+            carTransmission = itemView.findViewById(R.id.carTransmission);
+            carSeats = itemView.findViewById(R.id.carSeats);
+            carPrice = itemView.findViewById(R.id.carPrice);
+            carAvailability = itemView.findViewById(R.id.carAvailability);
+            rentButton = itemView.findViewById(R.id.rentButton);
+            rootCard = (MaterialCardView) itemView;
+        }
+
+        void bind(Car car, OnCarClickListener listener) {
+            carModel.setText(car.getModel());
+            carType.setText(car.getType());
+
+            String transmission = car.getTransmissionType();
+            if (transmission == null || transmission.trim().isEmpty()) {
+                transmission = itemView.getContext().getString(R.string.transmission_unknown);
+            }
+            carTransmission.setText(transmission);
+
+            int seats = car.getSeats();
+            String seatsText = seats > 0
+                    ? itemView.getResources().getQuantityString(R.plurals.car_seats_count, seats, seats)
+                    : itemView.getContext().getString(R.string.seats_unknown);
+            carSeats.setText(seatsText);
+
+            carPrice.setText(String.format(itemView.getContext().getString(R.string.price_per_day_format), car.getPricePerDay()));
+
+            if (car.isAvailable()) {
+                carAvailability.setText(itemView.getContext().getString(R.string.car_available));
+                carAvailability.setVisibility(View.VISIBLE);
+                rentButton.setEnabled(true);
+                rentButton.setAlpha(1f);
+            } else {
+                carAvailability.setVisibility(View.GONE);
+                rentButton.setEnabled(false);
+                rentButton.setAlpha(0.6f);
+            }
+
+            Glide.with(itemView.getContext())
+                    .load(car.getImageUrl())
+                    .placeholder(R.drawable.ic_app_logo)
+                    .error(R.drawable.ic_app_logo)
+                    .centerCrop()
+                    .into(carImage);
+
+            View.OnClickListener clickListener = v -> {
+                if (listener != null) {
+                    listener.onCarClicked(car);
+                }
+            };
+
+            rootCard.setOnClickListener(clickListener);
+            rentButton.setOnClickListener(clickListener);
+        }
+    }
+}

--- a/app/src/main/java/com/example/carrentingtest/admin/ManageCarsActivity.java
+++ b/app/src/main/java/com/example/carrentingtest/admin/ManageCarsActivity.java
@@ -2,9 +2,14 @@ package com.example.carrentingtest.admin;
 
 import android.app.AlertDialog;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.*;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
 
@@ -104,8 +109,12 @@ public class ManageCarsActivity extends AppCompatActivity {
         // Get references to all form fields
         EditText etModel = view.findViewById(R.id.etModel),
                 etType = view.findViewById(R.id.etType),
+                etSeats = view.findViewById(R.id.etSeats),
                 etPrice = view.findViewById(R.id.etPrice),
                 etImageUrl = view.findViewById(R.id.etImageUrl);
+        RadioGroup rgTransmission = view.findViewById(R.id.rgTransmission);
+        RadioButton rbAutomatic = view.findViewById(R.id.rbAutomatic);
+        RadioButton rbManual = view.findViewById(R.id.rbManual);
         SwitchCompat swAvailable = view.findViewById(R.id.swAvailable);
 
         boolean isEdit = car != null;  // Determine if we're editing or adding
@@ -115,9 +124,21 @@ public class ManageCarsActivity extends AppCompatActivity {
         if (isEdit) {
             etModel.setText(car.getModel());
             etType.setText(car.getType());
+            if (car.getSeats() > 0) {
+                etSeats.setText(String.valueOf(car.getSeats()));
+            }
             etPrice.setText(String.valueOf(car.getPricePerDay()));
             etImageUrl.setText(car.getImageUrl());
             swAvailable.setChecked(car.isAvailable());
+
+            String transmission = car.getTransmissionType();
+            if (!TextUtils.isEmpty(transmission)) {
+                if (transmission.equalsIgnoreCase(getString(R.string.transmission_manual))) {
+                    rgTransmission.check(R.id.rbManual);
+                } else {
+                    rgTransmission.check(R.id.rbAutomatic);
+                }
+            }
         }
 
         // Configure dialog buttons and behavior
@@ -127,10 +148,23 @@ public class ManageCarsActivity extends AppCompatActivity {
                     // Create or get the car object to save
                     Car c = isEdit ? car : new Car();
                     // Set all properties from form fields
-                    c.setModel(etModel.getText().toString());
-                    c.setType(etType.getText().toString());
-                    c.setPricePerDay(Double.parseDouble(etPrice.getText().toString()));
+                    c.setModel(etModel.getText().toString().trim());
+                    c.setType(etType.getText().toString().trim());
+
+                    String seatsText = etSeats.getText().toString().trim();
+                    int seats = TextUtils.isEmpty(seatsText) ? 0 : Integer.parseInt(seatsText);
+                    c.setSeats(seats);
+
+                    String priceText = etPrice.getText().toString().trim();
+                    double price = TextUtils.isEmpty(priceText) ? 0 : Double.parseDouble(priceText);
+                    c.setPricePerDay(price);
                     c.setImageUrl(etImageUrl.getText().toString());
+
+                    int selectedTransmissionId = rgTransmission.getCheckedRadioButtonId();
+                    String transmissionValue = selectedTransmissionId == R.id.rbManual
+                            ? getString(R.string.transmission_manual)
+                            : getString(R.string.transmission_automatic);
+                    c.setTransmissionType(transmissionValue);
                     // Set availability (only for edits, new cars are available by default)
                     if (isEdit) c.setAvailable(swAvailable.isChecked());
                     else c.setAvailable(true);

--- a/app/src/main/java/com/example/carrentingtest/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/carrentingtest/fragments/HomeFragment.java
@@ -7,10 +7,10 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.LinearLayout;
-import android.widget.ListView;
 import android.widget.Toast;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
@@ -18,8 +18,9 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import com.example.carrentingtest.R;
 import com.example.carrentingtest.RentalFormActivity;
-import com.example.carrentingtest.adapters.CarAdapter;
+import com.example.carrentingtest.adapters.CarGridAdapter;
 import com.example.carrentingtest.models.Car;
+import com.example.carrentingtest.utils.GridSpacingItemDecoration;
 import com.google.android.material.button.MaterialButton;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -30,8 +31,8 @@ import java.util.List;
 public class HomeFragment extends Fragment {
 
     private static final String TAG = "HomeFragment";
-    private ListView carsListView;
-    private CarAdapter carAdapter;
+    private RecyclerView carsRecyclerView;
+    private CarGridAdapter carAdapter;
     private List<Car> carList;
     private List<Car> filteredCarList; // For search/filter functionality
     private FirebaseFirestore db;
@@ -66,27 +67,29 @@ public class HomeFragment extends Fragment {
         }
 
         // Initialize views
-        carsListView = view.findViewById(R.id.carsListView);
+        carsRecyclerView = view.findViewById(R.id.carsRecyclerView);
         searchView = view.findViewById(R.id.searchView);
         filterContainer = view.findViewById(R.id.filterContainer);
 
         // Initialize car lists
         carList = new ArrayList<>();
         filteredCarList = new ArrayList<>();
-        carAdapter = new CarAdapter(requireContext(), filteredCarList); // Use filtered list for adapter
-        carsListView.setAdapter(carAdapter);
-
-        // Set item click listener for ListView
-        carsListView.setOnItemClickListener((parent, view1, position, id) -> {
-            Car selectedCar = filteredCarList.get(position); // Get car from filtered list
+        carAdapter = new CarGridAdapter(filteredCarList, selectedCar -> {
             if (selectedCar.isAvailable()) {
                 Intent intent = new Intent(getActivity(), RentalFormActivity.class);
-                intent.putExtra("selectedCar", selectedCar); // Pass Car object
+                intent.putExtra("selectedCar", selectedCar);
                 startActivity(intent);
             } else {
                 Toast.makeText(getContext(), "This car is currently unavailable.", Toast.LENGTH_SHORT).show();
             }
         });
+        carsRecyclerView.setAdapter(carAdapter);
+        GridLayoutManager layoutManager = new GridLayoutManager(requireContext(), 2);
+        carsRecyclerView.setLayoutManager(layoutManager);
+        int spacing = getResources().getDimensionPixelSize(R.dimen.home_car_grid_spacing);
+        carsRecyclerView.addItemDecoration(new GridSpacingItemDecoration(2, spacing, true));
+        carsRecyclerView.setClipToPadding(false);
+        carsRecyclerView.setHasFixedSize(true);
 
         // Setup search functionality
         setupSearchView();
@@ -187,7 +190,7 @@ public class HomeFragment extends Fragment {
                 filteredCarList.add(car);
             }
         }
-        carAdapter.notifyDataSetChanged(); // Update the ListView
+        carAdapter.notifyDataSetChanged(); // Update the RecyclerView grid
         Log.d(TAG, "Applied filters. Type: " + currentFilterType + ", Query: '" + currentSearchQuery + "'. Filtered list size: " + filteredCarList.size());
     }
 

--- a/app/src/main/java/com/example/carrentingtest/models/Car.java
+++ b/app/src/main/java/com/example/carrentingtest/models/Car.java
@@ -10,6 +10,8 @@ public class Car implements Serializable {
     private String imageUrl;
     private boolean available;
     private String companyId;
+    private int seats;
+    private String transmissionType;
 
     // Empty constructor for Firestore
     public Car() {}
@@ -37,4 +39,10 @@ public class Car implements Serializable {
 
     public String getCompanyId() { return companyId; }
     public void setCompanyId(String companyId) { this.companyId = companyId; }
+
+    public int getSeats() { return seats; }
+    public void setSeats(int seats) { this.seats = seats; }
+
+    public String getTransmissionType() { return transmissionType; }
+    public void setTransmissionType(String transmissionType) { this.transmissionType = transmissionType; }
 }

--- a/app/src/main/java/com/example/carrentingtest/utils/GridSpacingItemDecoration.java
+++ b/app/src/main/java/com/example/carrentingtest/utils/GridSpacingItemDecoration.java
@@ -1,0 +1,42 @@
+package com.example.carrentingtest.utils;
+
+import android.graphics.Rect;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class GridSpacingItemDecoration extends RecyclerView.ItemDecoration {
+
+    private final int spanCount;
+    private final int spacing;
+    private final boolean includeEdge;
+
+    public GridSpacingItemDecoration(int spanCount, int spacing, boolean includeEdge) {
+        this.spanCount = spanCount;
+        this.spacing = spacing;
+        this.includeEdge = includeEdge;
+    }
+
+    @Override
+    public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+        int position = parent.getChildAdapterPosition(view);
+        int column = position % spanCount;
+
+        if (includeEdge) {
+            outRect.left = spacing - column * spacing / spanCount;
+            outRect.right = (column + 1) * spacing / spanCount;
+
+            if (position < spanCount) {
+                outRect.top = spacing;
+            }
+            outRect.bottom = spacing;
+        } else {
+            outRect.left = column * spacing / spanCount;
+            outRect.right = spacing - (column + 1) * spacing / spanCount;
+            if (position >= spanCount) {
+                outRect.top = spacing;
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_car_form.xml
+++ b/app/src/main/res/layout/dialog_car_form.xml
@@ -33,6 +33,50 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
+        android:hint="@string/hint_seats">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etSeats"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
+        android:text="@string/label_transmission"
+        android:textColor="@color/textColorPrimary"
+        android:textStyle="bold" />
+
+    <RadioGroup
+        android:id="@+id/rgTransmission"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="12dp"
+        android:gravity="center_vertical">
+
+        <RadioButton
+            android:id="@+id/rbAutomatic"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:text="@string/transmission_automatic"
+            android:checked="true" />
+
+        <RadioButton
+            android:id="@+id/rbManual"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/transmission_manual" />
+    </RadioGroup>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:hint="Price per day">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -3,14 +3,18 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/bottomNavBackground"
-    android:padding="20dp">
+    android:background="@color/homeBackground"
+    android:paddingStart="@dimen/home_screen_padding"
+    android:paddingEnd="@dimen/home_screen_padding"
+    android:paddingTop="32dp"
+    android:paddingBottom="@dimen/home_section_spacing">
 
     <LinearLayout
         android:id="@+id/headerContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:paddingBottom="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -21,93 +25,135 @@
             android:layout_height="wrap_content"
             android:text="@string/home_hero_title"
             android:textColor="@color/textColorPrimary"
-            android:textSize="24sp"
-            android:textStyle="bold" />
+            android:textSize="26sp"
+            android:textStyle="bold"
+            android:letterSpacing="0.01" />
 
         <TextView
             android:id="@+id/homeSubtitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="8dp"
             android:text="@string/home_hero_caption"
             android:textColor="@color/textColorSecondary"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            android:lineSpacingExtra="2dp" />
     </LinearLayout>
 
-    <androidx.appcompat.widget.SearchView
-        android:id="@+id/searchView"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/searchCard"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:iconifiedByDefault="false"
-        android:queryHint="@string/search_field_hint"
+        android:layout_marginTop="@dimen/home_header_spacing"
+        app:cardBackgroundColor="@color/homeSearchBackground"
+        app:cardCornerRadius="20dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/homeSearchStroke"
+        app:strokeWidth="1dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/headerContainer" />
+        app:layout_constraintTop_toBottomOf="@id/headerContainer">
 
-    <LinearLayout
-        android:id="@+id/filterContainer"
+        <androidx.appcompat.widget.SearchView
+            android:id="@+id/searchView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:iconifiedByDefault="false"
+            android:padding="12dp"
+            android:queryHint="@string/search_field_hint" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/filterLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/home_section_spacing"
+        android:text="@string/home_filter_label"
+        android:textColor="@color/textColorPrimary"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/searchCard" />
+
+    <HorizontalScrollView
+        android:id="@+id/filterScroll"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:gravity="center"
-        android:orientation="horizontal"
-        android:paddingVertical="4dp"
+        android:layout_marginTop="12dp"
+        android:overScrollMode="never"
+        android:scrollbars="none"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchView">
+        app:layout_constraintTop_toBottomOf="@id/filterLabel">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnAll"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="0dp"
+        <LinearLayout
+            android:id="@+id/filterContainer"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_weight="1"
-            android:text="@string/all"
-            android:textAllCaps="false" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnSUV"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_weight="1"
-            android:text="@string/suv"
-            android:textAllCaps="false" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnAll"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:layout_marginEnd="12dp"
+                android:minWidth="0dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:text="@string/all"
+                android:textAllCaps="false" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnCompact"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_weight="1"
-            android:text="@string/compact"
-            android:textAllCaps="false" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnSUV"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:layout_marginEnd="12dp"
+                android:minWidth="0dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:text="@string/suv"
+                android:textAllCaps="false" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnLuxury"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/luxury"
-            android:textAllCaps="false" />
-    </LinearLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCompact"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:layout_marginEnd="12dp"
+                android:minWidth="0dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:text="@string/compact"
+                android:textAllCaps="false" />
 
-    <ListView
-        android:id="@+id/carsListView"
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnLuxury"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:minWidth="0dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:text="@string/luxury"
+                android:textAllCaps="false" />
+        </LinearLayout>
+    </HorizontalScrollView>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/carsRecyclerView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="20dp"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="16dp"
-        android:listSelector="@android:color/transparent"
+        android:layout_marginTop="@dimen/home_section_spacing"
+        android:clipToPadding="false"
+        android:overScrollMode="never"
+        android:paddingBottom="@dimen/home_section_spacing"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/filterContainer" />
+        app:layout_constraintTop_toBottomOf="@id/filterScroll" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_car.xml
+++ b/app/src/main/res/layout/item_car.xml
@@ -4,62 +4,38 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginEnd="16dp"
-    android:layout_marginBottom="16dp"
     android:foreground="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
     app:cardBackgroundColor="@color/white"
-    app:cardCornerRadius="24dp"
-    app:cardElevation="2dp"
-    app:strokeColor="@color/black"
-    app:strokeWidth="0.5dp">
+    app:cardCornerRadius="22dp"
+    app:cardElevation="6dp"
+    app:strokeColor="@color/homeCardStroke"
+    app:strokeWidth="1dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="20dp">
+        android:padding="18dp">
 
         <!-- Header Section -->
-        <LinearLayout
-            android:id="@+id/headerSection"
-            android:layout_width="0dp"
+        <TextView
+            android:id="@+id/carAvailability"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
-            app:layout_constraintTop_toTopOf="parent"
+            android:background="@drawable/bg_badge_luxury"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
+            android:fontFamily="sans-serif-medium"
+            android:letterSpacing="0.05"
+            android:text="@string/car_available"
+            android:textAllCaps="true"
+            android:textColor="@color/homeHighlightTitle"
+            android:textSize="10sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
-
-            <TextView
-                android:id="@+id/carAvailability"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@drawable/bg_badge_luxury"
-                android:paddingStart="12dp"
-                android:paddingEnd="12dp"
-                android:paddingTop="6dp"
-                android:paddingBottom="6dp"
-                android:fontFamily="sans-serif-medium"
-                android:letterSpacing="0.05"
-                android:text="@string/car_available"
-                android:textAllCaps="true"
-                android:textColor="@color/homeHighlightTitle"
-                android:textSize="10sp" />
-
-            <View
-                android:layout_width="0dp"
-                android:layout_height="1dp"
-                android:layout_weight="1" />
-
-            <ImageView
-                android:id="@+id/favoriteIcon"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_favorite_border"
-                app:tint="@color/iconTint"
-                android:contentDescription="@string/favorite" />
-
-        </LinearLayout>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <!-- Car Image with Gradient Background -->
         <androidx.cardview.widget.CardView
@@ -69,7 +45,7 @@
             android:layout_marginTop="16dp"
             app:cardCornerRadius="16dp"
             app:cardElevation="0dp"
-            app:layout_constraintTop_toBottomOf="@id/headerSection"
+            app:layout_constraintTop_toBottomOf="@id/carAvailability"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">
 
@@ -78,7 +54,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
-                android:scaleType="centerInside"
+                android:scaleType="centerCrop"
                 android:src="@drawable/car_placeholder"
                 android:contentDescription="@string/car_image_content_description" />
 
@@ -109,6 +85,7 @@
             android:layout_marginTop="12dp"
             android:orientation="horizontal"
             android:gravity="start"
+            android:baselineAligned="false"
             app:layout_constraintTop_toBottomOf="@id/carModel"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">
@@ -160,7 +137,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="6dp"
-                    android:text="Auto"
+                    android:text="@string/transmission_unknown"
                     android:textColor="@color/textColorSecondary"
                     android:textSize="13sp"
                     android:fontFamily="sans-serif" />
@@ -186,7 +163,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="6dp"
-                    android:text="4 Seats"
+                    android:text="@string/seats_unknown"
                     android:textColor="@color/textColorSecondary"
                     android:textSize="13sp"
                     android:fontFamily="sans-serif" />
@@ -250,14 +227,16 @@
                 android:id="@+id/rentButton"
                 android:layout_width="wrap_content"
                 android:layout_height="48dp"
-                android:text="Rent Now"
+                android:text="@string/rent_now"
                 android:textAllCaps="false"
                 android:textSize="14sp"
                 android:fontFamily="sans-serif-medium"
                 android:paddingStart="24dp"
                 android:paddingEnd="24dp"
+                android:textColor="@color/colorOnPrimary"
                 app:cornerRadius="12dp"
                 app:elevation="0dp"
+                app:backgroundTint="@color/colorPrimary"
                 style="@style/Widget.MaterialComponents.Button" />
 
         </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="home_horizontal_padding">20dp</dimen>
+    <dimen name="home_screen_padding">24dp</dimen>
+    <dimen name="home_header_spacing">16dp</dimen>
     <dimen name="home_section_spacing">24dp</dimen>
+    <dimen name="home_car_grid_spacing">16dp</dimen>
     <dimen name="home_filter_chip_stroke_width">1dp</dimen>
     <dimen name="home_hero_bottom_padding">72dp</dimen>
     <dimen name="home_search_card_translation">-48dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="home_hero_caption">Exclusive fleet, premium support and seamless verification</string>
     <string name="home_highlight_title">Member concierge</string>
     <string name="home_highlight_subtitle">Personalized car recommendations and priority pick-up</string>
+    <string name="home_filter_label">Browse by type</string>
     <string name="home_quick_filters">Quick filters</string>
     <string name="filter_suv_getaways">SUV getaways</string>
     <string name="filter_under_price_daily">Under $90/day</string>
@@ -62,6 +63,7 @@
     <string name="suv">SUV</string>
     <string name="compact">Compact</string>
     <string name="luxury">Luxury</string>
+    <string name="rent_now">Rent now</string>
     <string name="available_for_rent">Available for rent</string>
     <string name="add_new_car">Add New Car</string>
     <string name="company_name">Company Name</string>
@@ -99,6 +101,16 @@
     <string name="car_available">Available</string>
     <string name="price_per_day_format">%.2f dhs / day</string>
     <string name="car_image_content_description">Car preview</string>
+    <string name="hint_seats">Number of seats</string>
+    <string name="label_transmission">Transmission</string>
+    <string name="transmission_automatic">Automatic</string>
+    <string name="transmission_manual">Manual</string>
+    <string name="transmission_unknown">Transmission</string>
+    <string name="seats_unknown">Seats</string>
+    <plurals name="car_seats_count">
+        <item quantity="one">%d seat</item>
+        <item quantity="other">%d seats</item>
+    </plurals>
     <string name="full_name">Full Name</string>
     <string name="email">Email</string>
     <string name="next">Next</string>


### PR DESCRIPTION
## Summary
- redesign the home fragment with a spacious card grid layout and horizontal filter controls
- introduce a RecyclerView grid adapter and spacing decoration to render cars with availability, seats and transmission details
- require admins to capture seats and transmission when managing cars and surface new strings and layout polish

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4bf973f88333bd0a7fd069d4f842