### PR TITLE
Restyle bottom navigation bar

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,18 +12,38 @@
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/bottom_navigation" />
+        android:layout_above="@+id/bottom_nav_container" />
 
-    <!-- Bottom Navigation View -->
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
+    <!-- Elevated Bottom Navigation -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/bottom_nav_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:background="@color/bottomNavBackground"
-        app:itemIconTint="@color/bottom_nav_item_color_selector" 
-        app:itemTextColor="@color/bottom_nav_item_color_selector"
-        app:menu="@menu/bottom_nav_menu" />
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="24dp"
+        android:clipToPadding="false"
+        app:cardCornerRadius="28dp"
+        app:cardElevation="12dp"
+        app:cardUseCompatPadding="false"
+        app:strokeColor="@android:color/transparent"
+        app:cardBackgroundColor="@color/palette_white">
+
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottom_navigation"
+            style="@style/Widget.CarRentingTest.BottomNavigation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            app:itemIconTint="@color/bottom_nav_item_color_selector"
+            app:itemTextAppearanceActive="@style/TextAppearance.CarRentingTest.BottomNav.Active"
+            app:itemTextAppearanceInactive="@style/TextAppearance.CarRentingTest.BottomNav.Inactive"
+            app:itemTextColor="@color/bottom_nav_item_color_selector"
+            app:labelVisibilityMode="labeled"
+            app:menu="@menu/bottom_nav_menu" />
+
+    </com.google.android.material.card.MaterialCardView>
 
 </RelativeLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Widget.CarRentingTest.BottomNavigation" parent="@style/Widget.Material3.BottomNavigationView">
+        <item name="android:paddingLeft">12dp</item>
+        <item name="android:paddingRight">12dp</item>
+        <item name="android:paddingStart">12dp</item>
+        <item name="android:paddingEnd">12dp</item>
+        <item name="android:paddingTop">6dp</item>
+        <item name="android:paddingBottom">6dp</item>
+        <item name="itemIconSize">22dp</item>
+        <item name="itemActiveIndicatorStyle">@style/Widget.CarRentingTest.BottomNavigation.ActiveIndicator</item>
+        <item name="itemRippleColor">@color/homeFilterRipple</item>
+    </style>
+
+    <style name="Widget.CarRentingTest.BottomNavigation.ActiveIndicator">
+        <item name="android:width">72dp</item>
+        <item name="android:height">32dp</item>
+        <item name="android:color">@color/palette_light_blue</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.CarRentingTest.BottomNav.ActiveIndicator</item>
+    </style>
+
+    <style name="ShapeAppearance.CarRentingTest.BottomNav.ActiveIndicator" parent="@style/ShapeAppearance.Material3.Corner.Large">
+        <item name="cornerSizeTopLeft">16dp</item>
+        <item name="cornerSizeTopRight">16dp</item>
+        <item name="cornerSizeBottomLeft">16dp</item>
+        <item name="cornerSizeBottomRight">16dp</item>
+    </style>
+
+    <style name="TextAppearance.CarRentingTest.BottomNav.Active" parent="@style/TextAppearance.Material3.LabelMedium">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textFontWeight">600</item>
+    </style>
+
+    <style name="TextAppearance.CarRentingTest.BottomNav.Inactive" parent="@style/TextAppearance.Material3.LabelSmall">
+        <item name="android:textSize">11sp</item>
+        <item name="android:textFontWeight">500</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- wrap the bottom navigation in an elevated MaterialCardView to create a compact floating appearance
- introduce dedicated bottom navigation styles for tighter padding, smaller icons, and rounded active indicators

## Testing
- `./gradlew lintDebug` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddca56cccc833384a43a610829fbfe