### PR TITLE
Revamp profile screen UI

### DIFF
--- a/app/src/main/res/drawable/bg_profile_header_card.xml
+++ b/app/src/main/res/drawable/bg_profile_header_card.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="28dp" />
+    <gradient
+        android:angle="135"
+        android:endColor="@color/homeHeroEnd"
+        android:startColor="@color/homeHeroStart" />
+</shape>

--- a/app/src/main/res/drawable/bg_profile_icon.xml
+++ b/app/src/main/res/drawable/bg_profile_icon.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="@color/homeChipBackground" />
+</shape>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -3,149 +3,124 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white">
+    android:background="@color/colorBackground"
+    android:clipToPadding="false">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="16dp"
-        android:gravity="center_horizontal">
+        android:padding="24dp"
+        android:gravity="center_horizontal"
+        android:clipToPadding="false">
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="24dp"
+            android:letterSpacing="0.04"
             android:text="@string/my_profile"
-            android:textSize="22sp"
-            android:textStyle="bold"
             android:textColor="@color/textColorPrimary"
-            android:gravity="start"
-            android:layout_marginBottom="16dp"/>
+            android:textSize="28sp"
+            android:textStyle="bold" />
 
-        <!-- Profile Picture Section -->
-        <ImageView
-            android:id="@+id/ivProfilePicture"
-            android:layout_width="96dp"
-            android:layout_height="96dp"
-            android:src="@drawable/ic_person_placeholder"
-            android:scaleType="centerCrop"
-            android:background="@drawable/bg_profile_avatar"
-            android:padding="8dp"
-            android:layout_marginBottom="8dp"/>
-
-        <!-- Main Profile Information Card -->
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:cardCornerRadius="16dp"
+            app:cardBackgroundColor="@android:color/transparent"
+            app:cardCornerRadius="28dp"
             app:cardElevation="0dp"
-            app:strokeColor="@color/colorPrimary"
-            app:strokeWidth="1dp"
-            android:layout_marginBottom="16dp">
+            app:cardUseCompatPadding="false">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_profile_header_card"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
+                android:padding="28dp">
+
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:id="@+id/ivProfilePicture"
+                    android:layout_width="96dp"
+                    android:layout_height="96dp"
+                    android:layout_marginBottom="16dp"
+                    android:background="@android:color/transparent"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_person_placeholder"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.CarRentingTest.Circle"
+                    app:strokeColor="@color/colorOnPrimary"
+                    app:strokeWidth="2dp" />
+
+                <TextView
+                    android:id="@+id/tvProfileName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:letterSpacing="0.02"
+                    android:text="@string/loading"
+                    android:textColor="@color/colorOnPrimary"
+                    android:textSize="22sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tvProfileEmail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:alpha="0.85"
+                    android:gravity="center"
+                    android:text="@string/loading"
+                    android:textColor="@color/colorOnPrimary"
+                    android:textSize="14sp" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:cardBackgroundColor="@color/colorSurface"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/homeCardStroke"
+            app:strokeWidth="1dp">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="16dp">
+                android:padding="24dp">
 
-                <!-- Name Section -->
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/profile_contact_title"
+                    android:textColor="@color/textColorPrimary"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:layout_marginBottom="16dp">
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
 
-                    <ImageView
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:src="@drawable/ic_person"
-                        android:layout_marginEnd="12dp"
-                        android:layout_gravity="center_vertical"
-                        app:tint="@color/colorPrimary"/>
+                    <FrameLayout
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:layout_marginEnd="16dp"
+                        android:background="@drawable/bg_profile_icon">
 
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/name_label"
-                            android:textSize="12sp"
-                            android:textColor="@color/textColorSecondary"
-                            android:textAllCaps="true"
-                            android:letterSpacing="0.1"/>
-
-                        <TextView
-                            android:id="@+id/tvProfileName"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/loading"
-                            android:textSize="18sp"
-                            android:textColor="@color/textColorPrimary"
-                            android:textStyle="bold"
-                            android:layout_marginTop="4dp"/>
-                    </LinearLayout>
-                </LinearLayout>
-
-                <!-- Email Section -->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:layout_marginBottom="16dp">
-
-                    <ImageView
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:src="@drawable/ic_email"
-                        android:layout_marginEnd="12dp"
-                        android:layout_gravity="center_vertical"
-                        app:tint="@color/colorPrimary"/>
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/email_label"
-                            android:textSize="12sp"
-                            android:textColor="@color/textColorSecondary"
-                            android:textAllCaps="true"
-                            android:letterSpacing="0.1"/>
-
-                        <TextView
-                            android:id="@+id/tvProfileEmail"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/loading"
-                            android:textSize="16sp"
-                            android:textColor="@color/textColorPrimary"
-                            android:layout_marginTop="4dp"/>
-                    </LinearLayout>
-                </LinearLayout>
-
-                <!-- Phone Section -->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:layout_marginBottom="16dp">
-
-                    <ImageView
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:src="@drawable/ic_phone"
-                        android:layout_marginEnd="12dp"
-                        android:layout_gravity="center_vertical"
-                        app:tint="@color/colorPrimary"/>
+                        <ImageView
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_phone"
+                            app:tint="@color/iconTint" />
+                    </FrameLayout>
 
                     <LinearLayout
                         android:layout_width="0dp"
@@ -157,35 +132,48 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/phone_label"
-                            android:textSize="12sp"
-                            android:textColor="@color/textColorSecondary"
                             android:textAllCaps="true"
-                            android:letterSpacing="0.1"/>
+                            android:textColor="@color/textColorSecondary"
+                            android:textSize="11sp"
+                            android:letterSpacing="0.12" />
 
                         <TextView
                             android:id="@+id/tvProfilePhone"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
                             android:text="@string/loading"
-                            android:textSize="16sp"
                             android:textColor="@color/textColorPrimary"
-                            android:layout_marginTop="4dp"/>
+                            android:textSize="16sp" />
                     </LinearLayout>
                 </LinearLayout>
 
-                <!-- Driver License Section -->
+                <com.google.android.material.divider.MaterialDivider
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="16dp"
+                    app:dividerColor="@color/homeCardStroke"
+                    app:dividerThickness="1dp" />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
                     android:orientation="horizontal">
 
-                    <ImageView
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:src="@drawable/ic_card_membership"
-                        android:layout_marginEnd="12dp"
-                        android:layout_gravity="center_vertical"
-                        app:tint="@color/colorPrimary"/>
+                    <FrameLayout
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:layout_marginEnd="16dp"
+                        android:background="@drawable/bg_profile_icon">
+
+                        <ImageView
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_card_membership"
+                            app:tint="@color/iconTint" />
+                    </FrameLayout>
 
                     <LinearLayout
                         android:layout_width="0dp"
@@ -197,105 +185,122 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/driver_license_label"
-                            android:textSize="12sp"
-                            android:textColor="@color/textColorSecondary"
                             android:textAllCaps="true"
-                            android:letterSpacing="0.1"/>
+                            android:textColor="@color/textColorSecondary"
+                            android:textSize="11sp"
+                            android:letterSpacing="0.12" />
 
                         <TextView
                             android:id="@+id/tvProfileLicense"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
                             android:text="@string/loading"
-                            android:textSize="16sp"
                             android:textColor="@color/textColorPrimary"
-                            android:layout_marginTop="4dp"/>
+                            android:textSize="16sp" />
                     </LinearLayout>
                 </LinearLayout>
-
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
-        <!-- Action Buttons -->
-        <LinearLayout
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center"
             android:layout_marginTop="16dp"
-            android:layout_marginBottom="24dp">
-
-            <!-- Identity & Safety Section -->
-            <com.google.android.material.card.MaterialCardView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:cardCornerRadius="12dp"
-                app:cardElevation="3dp"
-                android:layout_marginBottom="16dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="20dp">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Identity &amp; Safety"
-                        android:textStyle="bold"
-                        android:textSize="16sp"
-                        android:layout_marginBottom="12dp" />
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnVerifyLicense"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/verify_license"
-                        android:backgroundTint="@color/colorPrimary"
-                        android:textColor="@color/white"
-                        style="@style/Widget.MaterialComponents.Button"
-                        android:visibility="visible"/>
-
-                    <TextView
-                        android:id="@+id/txtVerifiedBadge"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/license_verified_badge"
-                        android:textColor="#2e7d32"
-                        android:visibility="gone"
-                        android:layout_marginTop="8dp"/>
-                </LinearLayout>
-            </com.google.android.material.card.MaterialCardView>
+            app:cardBackgroundColor="@color/colorSurface"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/homeCardStroke"
+            app:strokeWidth="1dp">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnEditProfile"
-                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                    android:layout_width="0dp"
+                android:orientation="vertical"
+                android:padding="24dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/edit_profile"
-                    android:textColor="@color/colorPrimary"
-                    app:strokeColor="@color/colorPrimary"
-                    app:icon="@drawable/ic_edit"
-                    app:iconTint="@color/colorPrimary"
-                    android:layout_marginEnd="8dp"/>
+                    android:text="@string/profile_identity_title"
+                    android:textColor="@color/textColorPrimary"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/profile_identity_description"
+                    android:textColor="@color/textColorSecondary"
+                    android:textSize="13sp" />
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnLogout"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="0dp"
+                    android:id="@+id/btnVerifyLicense"
+                    style="@style/Widget.MaterialComponents.Button"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/logout"
-                    android:textColor="@color/colorError"
-                    android:layout_marginStart="8dp"/>
+                    android:layout_marginTop="16dp"
+                    android:text="@string/verify_license"
+                    android:textAllCaps="false"
+                    android:textColor="@color/colorOnSecondary"
+                    android:visibility="visible"
+                    app:icon="@drawable/ic_card_membership"
+                    app:iconGravity="textStart"
+                    app:iconTint="@color/colorOnSecondary"
+                    app:rippleColor="@color/homeFilterRipple"
+                    app:backgroundTint="@color/colorSecondary" />
+
+                <TextView
+                    android:id="@+id/txtVerifiedBadge"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/license_verified_badge"
+                    android:textColor="@color/colorSuccess"
+                    android:textStyle="bold"
+                    android:visibility="gone" />
             </LinearLayout>
-        </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="32dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnEditProfile"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="12dp"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="@string/edit_profile"
+                android:textAllCaps="false"
+                android:textColor="@color/colorPrimary"
+                android:textSize="15sp"
+                app:icon="@drawable/ic_edit"
+                app:iconGravity="textStart"
+                app:iconPadding="8dp"
+                app:iconTint="@color/colorPrimary"
+                app:strokeColor="@color/homeCardStroke" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnLogout"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="@string/logout"
+                android:textAllCaps="false"
+                android:textColor="@color/colorError"
+                android:textSize="15sp" />
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -57,6 +57,9 @@
     <string name="email_label">البريد الإلكتروني:</string>
     <string name="phone_label">الهاتف:</string>
     <string name="driver_license_label">رخصة القيادة:</string>
+    <string name="profile_contact_title">بيانات التواصل</string>
+    <string name="profile_identity_title">الهوية والسلامة</string>
+    <string name="profile_identity_description">حافظ على توثيق حسابك لضمان حجوزات سلسة.</string>
     <string name="car_available">متاح</string>
     <string name="home_available_cars">المركبات المتاحة</string>
     <string name="price_per_day_format">%.2f درهم / اليوم</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -57,6 +57,9 @@
     <string name="email_label">E-mail :</string>
     <string name="phone_label">Téléphone :</string>
     <string name="driver_license_label">Permis de conduire :</string>
+    <string name="profile_contact_title">Coordonnées</string>
+    <string name="profile_identity_title">Identité &amp; Sécurité</string>
+    <string name="profile_identity_description">Maintenez votre compte vérifié pour des réservations fluides.</string>
     <string name="car_available">Disponible</string>
     <string name="home_available_cars">Véhicules disponibles</string>
     <string name="price_per_day_format">%.2f dhs / jour</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,9 @@
     <string name="email_label">Email:</string>
     <string name="phone_label">Phone:</string>
     <string name="driver_license_label">Driver License:</string>
+    <string name="profile_contact_title">Contact details</string>
+    <string name="profile_identity_title">Identity &amp; Safety</string>
+    <string name="profile_identity_description">Keep your account verified for seamless bookings.</string>
     <string name="car_available">Available</string>
     <string name="price_per_day_format"> dhs / day</string>
     <string name="car_image_content_description">Car preview</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -35,4 +35,9 @@
         <item name="android:textSize">11sp</item>
         <item name="android:textFontWeight">500</item>
     </style>
+
+    <style name="ShapeAppearanceOverlay.CarRentingTest.Circle">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">50%</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
- redesign the profile fragment with a gradient hero card, modern typography, and reorganized detail sections
- add supporting resources for icon backgrounds, circular avatar styling, and localized text for the new layout

## Testing
- not run (UI updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e2d9bb29a483338c84a34c2c126454