### PR TITLE
Fix missing parent for profile image shape overlay

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -36,7 +36,7 @@
         <item name="android:textFontWeight">500</item>
     </style>
 
-    <style name="ShapeAppearanceOverlay.CarRentingTest.Circle">
+    <style name="ShapeAppearanceOverlay.CarRentingTest.Circle" parent="@style/ShapeAppearanceOverlay.Material3.Corner.Full">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>


### PR DESCRIPTION
## Summary
- define the ShapeAppearanceOverlay.CarRentingTest.Circle style with a Material3 corner overlay parent to avoid implicit parent resolution errors

## Testing
- ./gradlew assembleDebug *(fails: SDK not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dbfe530c8333b8b2b71dd20c4b9b